### PR TITLE
Removes the epasControl message

### DIFF
--- a/panda/board/safety/safety_tesla.h
+++ b/panda/board/safety/safety_tesla.h
@@ -263,6 +263,11 @@ static int tesla_fwd_hook(int bus_num, CAN_FIFOMailBox_TypeDef *to_fwd) {
       return 2;
     }
 
+    // remove EPB_epasControl
+    if (addr == 0x214) {
+      return false;
+    }
+
     return 2; // Custom EPAS bus
   }
   if (bus_num == 2) {


### PR DESCRIPTION
Necessary for cars with an iBooster