### PR TITLE
Toggle between ACC/PCC based on cruise stalk

### DIFF
--- a/selfdrive/car/tesla/ACC_module.py
+++ b/selfdrive/car/tesla/ACC_module.py
@@ -3,9 +3,12 @@ from selfdrive.car.tesla.values import AH, CruiseButtons, CruiseState, CAR
 from selfdrive.config import Conversions as CV
 import selfdrive.messaging as messaging
 import os
+import collections
 import subprocess
+import sys
 import time
 import zmq
+  
 
 class ACCState(object):
   # Possible state of the ACC system, following the DI_cruiseState naming
@@ -14,26 +17,60 @@ class ACCState(object):
   STANDBY = 1     # Ready to be enaged.
   ENABLED = 2     # Engaged.
   NOT_READY = 9   # Not ready to be engaged due to the state of the car.
+  
+class Mode(object):
+  def __init__(self, label, autoresume, state):
+    self.label = label
+    self.autoresume = autoresume
+    self.state = state
+    
+  def set_next(self, next):
+    self.next = next
+  
+class ACCMode(object):
+  ON   = Mode(label="on",   autoresume=False, state=ACCState.STANDBY)
+  AUTO = Mode(label="auto", autoresume=True,  state=ACCState.STANDBY)
+  OFF  = Mode(label="off",  autoresume=False, state=ACCState.OFF)
+  
+  ON.set_next(AUTO)
+  AUTO.set_next(OFF)
+  OFF.set_next(ON)
+  
+  label_to_mode = {
+    ON.label: ON,
+    AUTO.label: AUTO,
+    OFF.label: OFF
+  }
+  
+  @ classmethod
+  def get(cls, name):
+    if name in cls.label_to_mode:
+      return cls.label_to_mode[name]
+    else:
+      return cls.OFF
+      
+  @ classmethod
+  def get_labels(cls):
+    return [label for label in cls.label_to_mode if label != cls.OFF.label]
 
 def _current_time_millis():
   return int(round(time.time() * 1000))
 
+
 class ACCController(object):
   
-  # Tesla cruise only functions above 18 MPH
-  MIN_CRUISE_SPEED_MS = 18 * CV.MPH_TO_MS
+  # Tesla cruise only functions above 17 MPH
+  MIN_CRUISE_SPEED_MS = 17.1 * CV.MPH_TO_MS
     
-  def __init__(self, carcontroller):
-    self.CC = carcontroller
+  def __init__(self):
     self.human_cruise_action_time = 0
     self.automated_cruise_action_time = 0
-    self.last_angle = 0.
     context = zmq.Context()
     self.poller = zmq.Poller()
     self.live20 = messaging.sub_sock(context, service_list['live20'].port, conflate=True, poller=self.poller)
-    self.lead_1 = None
     self.last_update_time = 0
     self.enable_adaptive_cruise = False
+    self.prev_enable_adaptive_cruise = False
     # Whether to re-engage automatically after being paused due to low speed or
     # user-initated deceleration.
     self.autoresume = False
@@ -41,33 +78,40 @@ class ACCController(object):
     self.prev_cruise_buttons = CruiseButtons.IDLE
     self.prev_pcm_acc_status = 0
     self.acc_speed_kph = 0.
-  
+    self.user_has_braked = False
+    self.has_gone_below_min_speed = False
+    self.fast_decel_time = 0
+    self.lead_last_seen_time_ms = 0
+
+  # Updates the internal state of this controller based on user input,
+  # specifically the steering wheel mounted cruise control stalk, and OpenPilot
+  # UI buttons.
   def update_stat(self, CS, enabled):
     # Check if the cruise stalk was double pulled, indicating that adaptive
     # cruise control should be enabled. Twice in .75 seconds counts as a double
     # pull.
-    prev_enable_adaptive_cruise = self.enable_adaptive_cruise
-    self.autoresume = CS.cstm_btns.get_button_label2("acc") == "AutoRes"
+    self.prev_enable_adaptive_cruise = self.enable_adaptive_cruise
+    acc_string = CS.cstm_btns.get_button_label2("acc")
+    acc_mode = ACCMode.get(acc_string)
+    CS.cstm_btns.get_button("acc").btn_label2 = acc_mode.label
+    self.autoresume = acc_mode.autoresume
     curr_time_ms = _current_time_millis()
-    speed_uom_kph = 1.
-    if CS.imperial_speed_units:
-      speed_uom_kph = CV.MPH_TO_KPH
     # Handle pressing the enable button.
     if (CS.cruise_buttons == CruiseButtons.MAIN and
         self.prev_cruise_buttons != CruiseButtons.MAIN):
       double_pull = curr_time_ms - self.last_cruise_stalk_pull_time < 750
       self.last_cruise_stalk_pull_time = curr_time_ms
-      ready = (CS.cstm_btns.get_button_status("acc") > ACCState.OFF and
-               enabled and
-               CruiseState.is_enabled_or_standby(CS.pcm_acc_status))
+      ready = (CS.cstm_btns.get_button_status("acc") > ACCState.OFF
+               and enabled
+               and CruiseState.is_enabled_or_standby(CS.pcm_acc_status)
+               and CS.v_ego > self.MIN_CRUISE_SPEED_MS)
       if ready and double_pull:
         # A double pull enables ACC. updating the max ACC speed if necessary.
         self.enable_adaptive_cruise = True
         # Increase ACC speed to match current, if applicable.
         self.acc_speed_kph = max(CS.v_ego_raw * CV.MS_TO_KPH, self.acc_speed_kph)
-      else:
-        # A single pull disables ACC (falling back to just steering).
-        self.enable_adaptive_cruise = False
+        self.user_has_braked = False
+        self.has_gone_below_min_speed = False
     # Handle pressing the cancel button.
     elif CS.cruise_buttons == CruiseButtons.CANCEL:
       self.enable_adaptive_cruise = False
@@ -76,37 +120,29 @@ class ACCController(object):
     # Handle pressing up and down buttons.
     elif (self.enable_adaptive_cruise and
           CS.cruise_buttons != self.prev_cruise_buttons):
-      # Real stalk command while ACC is already enabled. Adjust the max ACC
-      # speed if necessary. For example if max speed is 50 but you're currently
-      # only going 30, the cruise speed can be increased without any change to
-      # max ACC speed. If actual speed is already 50, the code also increases
-      # the max cruise speed.
-      if CS.cruise_buttons == CruiseButtons.RES_ACCEL:
-        requested_speed_kph = CS.v_ego * CV.MS_TO_KPH + speed_uom_kph
-        self.acc_speed_kph = max(self.acc_speed_kph, requested_speed_kph)
-      elif CS.cruise_buttons == CruiseButtons.RES_ACCEL_2ND:
-        requested_speed_kph = CS.v_ego * CV.MS_TO_KPH + 5 * speed_uom_kph
-        self.acc_speed_kph = max(self.acc_speed_kph, requested_speed_kph)
-      elif CS.cruise_buttons == CruiseButtons.DECEL_SET:
-        self.acc_speed_kph -= speed_uom_kph
-      elif CS.cruise_buttons == CruiseButtons.DECEL_2ND:
-        self.acc_speed_kph -= 5 * speed_uom_kph
-      # Clip ACC speed between 0 and 170 KPH.
-      self.acc_speed_kph = min(self.acc_speed_kph, 170)
-      self.acc_speed_kph = max(self.acc_speed_kph, 0)
-    # If something disabled cruise control, disable ACC too.
-    elif (self.prev_pcm_acc_status == 2 and
-          CS.pcm_acc_status != 2 and
-          not self.autoresume):
-      self.enable_adaptive_cruise = False
+      self._update_max_acc_speed(CS)
+      
+    if CS.brake_pressed:
+      self.user_has_braked = True
+      if not self.autoresume:
+        self.enable_adaptive_cruise = False
+        
+    if CS.v_ego < self.MIN_CRUISE_SPEED_MS:
+      self.has_gone_below_min_speed = True
+    
+    # If autoresume is not enabled, manually steering or slowing disables ACC.
+    if not self.autoresume:
+      if not enabled or self.user_has_braked or self.has_gone_below_min_speed:
+        self.enable_adaptive_cruise = False
     
     # Notify if ACC was toggled
-    if prev_enable_adaptive_cruise and not self.enable_adaptive_cruise:
+    if self.prev_enable_adaptive_cruise and not self.enable_adaptive_cruise:
       CS.UE.custom_alert_message(3, "ACC Disabled", 150, 4)
       CS.cstm_btns.set_button_status("acc", ACCState.STANDBY)
-    elif self.enable_adaptive_cruise and not prev_enable_adaptive_cruise:
-      CS.UE.custom_alert_message(2, "ACC Enabled", 150)
+    elif self.enable_adaptive_cruise:
       CS.cstm_btns.set_button_status("acc", ACCState.ENABLED)
+      if not self.prev_enable_adaptive_cruise:
+        CS.UE.custom_alert_message(2, "ACC Enabled", 150)
 
     # Update the UI to show whether the current car state allows ACC.
     if CS.cstm_btns.get_button_status("acc") in [ACCState.STANDBY, ACCState.NOT_READY]:
@@ -120,76 +156,51 @@ class ACCController(object):
     # Update prev state after all other actions.
     self.prev_cruise_buttons = CS.cruise_buttons
     self.prev_pcm_acc_status = CS.pcm_acc_status
+    
+  def _update_max_acc_speed(self, CS):
+    # Adjust the max ACC speed based on user cruise stalk actions.
+    half_press_kph, full_press_kph = self._get_cc_units_kph(CS.imperial_speed_units)
+    speed_change_map = {
+      CruiseButtons.RES_ACCEL:     half_press_kph,
+      CruiseButtons.RES_ACCEL_2ND: full_press_kph,
+      CruiseButtons.DECEL_SET:     -1 * half_press_kph,
+      CruiseButtons.DECEL_2ND:     -1 * full_press_kph
+    }
+    self.acc_speed_kph += speed_change_map.get(CS.cruise_buttons, 0)
 
+    # Clip ACC speed between 0 and 170 KPH.
+    self.acc_speed_kph = min(self.acc_speed_kph, 170)
+    self.acc_speed_kph = max(self.acc_speed_kph, 0)
+    
+  # Decide which cruise control buttons to simluate to get the car to the
+  # desired speed.
   def update_acc(self, enabled, CS, frame, actuators, pcm_speed):
     # Adaptive cruise control
     current_time_ms = _current_time_millis()
     if CruiseButtons.should_be_throttled(CS.cruise_buttons):
       self.human_cruise_action_time = current_time_ms
     button_to_press = None
-    # The difference between OP's target speed and the current cruise
-    # control speed, in KPH.
-    speed_offset = (pcm_speed * CV.MS_TO_KPH - CS.v_cruise_actual)
+    
+    # If ACC is disabled, disengage traditional cruise control.
+    if (self.prev_enable_adaptive_cruise and not self.enable_adaptive_cruise
+        and CS.pcm_acc_status == CruiseState.ENABLED):
+      button_to_press = CruiseButtons.CANCEL
 
-    if (self.enable_adaptive_cruise
-        # Only do ACC if OP is steering
-        and enabled
-        # And adjust infrequently, since sending repeated adjustments makes
-        # the car think we're doing a 'long press' on the cruise stalk,
-        # resulting in small, jerky speed adjustments.
-        and current_time_ms > self.automated_cruise_action_time + 500):
-      # Automatically engange traditional cruise if it is idle and we are
-      # going fast enough and we are accelerating.
-      if (CS.pcm_acc_status == 1
-          and CS.v_ego > self.MIN_CRUISE_SPEED_MS
-          and CS.a_ego >= 0.):
-        button_to_press = CruiseButtons.DECEL_2ND
-      # If traditional cruise is engaged, then control it.
-      elif (CS.pcm_acc_status == 2
-            # But don't make adjustments if a human has manually done so in
-            # the last 3 seconds. Human intention should not be overridden.
-            and current_time_ms > self.human_cruise_action_time + 3000):
-        if CS.imperial_speed_units:
-          # Imperial unit cars adjust cruise in units of 1 and 5 mph.
-          half_press_kph = 1 * CV.MPH_TO_KPH
-          full_press_kph = 5 * CV.MPH_TO_KPH
-        else:
-          # Metric cars adjust cruise in units of 1 and 5 kph.
-          half_press_kph = 1
-          full_press_kph = 5
-        
-        # Reduce cruise speed significantly if necessary. Multiply by a % to
-        # make the car slightly more eager to slow down vs speed up.
-        if speed_offset < -0.6 * full_press_kph and CS.v_cruise_actual > 0:
-          # Send cruise stalk dn_2nd.
-          button_to_press = CruiseButtons.DECEL_2ND
-        # Reduce speed slightly if necessary.
-        elif speed_offset < -0.9 * half_press_kph and CS.v_cruise_actual > 0:
-          # Send cruise stalk dn_1st.
-          button_to_press = CruiseButtons.DECEL_SET
-        # Increase cruise speed if possible.
-        elif CS.v_ego > self.MIN_CRUISE_SPEED_MS:
-          # How much we can accelerate without exceeding max allowed speed.
-          available_speed = self.acc_speed_kph - CS.v_cruise_actual
-          if speed_offset > full_press_kph and full_press_kph < available_speed:
-            # Send cruise stalk up_2nd.
-            button_to_press = CruiseButtons.RES_ACCEL_2ND
-          elif speed_offset > half_press_kph and half_press_kph < available_speed:
-            # Send cruise stalk up_1st.
-            button_to_press = CruiseButtons.RES_ACCEL
-      if CS.cstm_btns.get_button_label2_index("acc") == 1:
+    if self.enable_adaptive_cruise and enabled:
+      if CS.cstm_btns.get_button_label2("acc") in ["OP", "AutoOP"]:    
+        button_to_press = self._calc_button(CS, pcm_speed)
+      else:
         # Alternative speed decision logic that uses the lead car's distance
         # and speed more directly.
         # Bring in the lead car distance from the Live20 feed
-        l20 = None
+        lead_1 = None
         if enabled:
           for socket, _ in self.poller.poll(0):
             if socket is self.live20:
-              l20 = messaging.recv_one(socket)
-              break
-        if l20 is not None:
-          self.lead_1 = l20.live20.leadOne
-        button_to_press = self.calc_follow_button(CS)
+              lead_1 = messaging.recv_one(socket).live20.leadOne
+              if lead_1.dRel:
+                self.lead_last_seen_time_ms = current_time_ms
+        button_to_press = self._calc_follow_button(CS, lead_1)
     if button_to_press:
       self.automated_cruise_action_time = current_time_ms
       # If trying to slow below the min cruise speed, just cancel cruise.
@@ -198,120 +209,220 @@ class ACCController(object):
       if (CruiseButtons.is_decel(button_to_press)
           and CS.v_cruise_actual - 1 < self.MIN_CRUISE_SPEED_MS * CV.MS_TO_KPH):
         button_to_press = CruiseButtons.CANCEL
+      if button_to_press == CruiseButtons.CANCEL:
+        self.fast_decel_time = current_time_ms
       # Debug logging (disable in production to reduce latency of commands)
       #print "***ACC command: %s***" % button_to_press
-    #elif (current_time_ms > self.last_update_time + 1000):
-    #  self.last_update_time = current_time_ms
-    #  print "Desired ACC speed change: %s" % (speed_offset)
     return button_to_press
 
   # function to calculate the cruise button based on a safe follow distance
-  def calc_follow_button(self, CS):
-    follow_time = 2.0 # in seconds
+  def _calc_follow_button(self, CS, lead_car):
+    if lead_car is None:
+      return None
+    # Desired gap (in seconds) between cars.
+    follow_time_s = 2.0
+    # v_ego is in m/s, so safe_dist_m is in meters.
+    safe_dist_m = CS.v_ego * follow_time_s
     current_time_ms = _current_time_millis()
      # Make sure we were able to populate lead_1.
-    if self.lead_1 is None:
-      return None
     # dRel is in meters.
-    lead_dist = self.lead_1.dRel
-    # Grab the relative speed.
-    rel_speed = self.lead_1.vRel * CV.MS_TO_KPH
-    # Current speed in kph
-    cur_speed = CS.v_ego * CV.MS_TO_KPH
-    # v_ego is in m/s, so safe_dist_mance is in meters.
-    safe_dist_m = CS.v_ego * follow_time
+    lead_dist_m = lead_car.dRel
+    lead_speed_kph = (lead_car.vRel + CS.v_ego) * CV.MS_TO_KPH
+    # Relative velocity between the lead car and our set cruise speed.
+    future_vrel_kph = lead_speed_kph - CS.v_cruise_actual
     # How much we can accelerate without exceeding the max allowed speed.
-    available_speed = self.acc_speed_kph - CS.v_cruise_actual
-    # Metric cars adjust cruise in units of 1 and 5 kph.
-    half_press_kph = 1
-    full_press_kph = 5
-    # Imperial unit cars adjust cruise in units of 1 and 5 mph
-    if CS.imperial_speed_units:
-      half_press_kph = 1 * CV.MPH_TO_KPH
-      full_press_kph = 5 * CV.MPH_TO_KPH
+    available_speed_kph = self.acc_speed_kph - CS.v_cruise_actual
+    half_press_kph, full_press_kph = self._get_cc_units_kph(CS.imperial_speed_units)
     # button to issue
     button = None
     # debug msg
     msg = None
 
-    #print "dRel: ", self.lead_1.dRel," yRel: ", self.lead_1.yRel, " vRel: ", self.lead_1.vRel, " aRel: ", self.lead_1.aRel, " vLead: ", self.lead_1.vLead, " vLeadK: ", self.lead_1.vLeadK, " aLeadK: ",     self.lead_1.aLeadK
-
-    ###   Logic to determine best cruise speed ###
-
-    # Automatically engange traditional cruise if it is idle and we are
-    # going fast enough and accelerating.
-    if (CS.pcm_acc_status == 1
-        and self.enable_adaptive_cruise
-        and CS.v_ego > self.MIN_CRUISE_SPEED_MS
-        and CS.a_ego > 0.12):
-      button = CruiseButtons.DECEL_SET
+    # Automatically engage traditional cruise if ACC is active.
+    if self._should_autoengage_cc(CS, lead_car=lead_car) and self._no_action_for(milliseconds=100):
+      button = CruiseButtons.RES_ACCEL
     # If traditional cruise is engaged, then control it.
-    elif CS.pcm_acc_status == 2:
+    elif CS.pcm_acc_status == CruiseState.ENABLED:
+      
+      # Disengage cruise control if a slow object is seen ahead. This triggers
+      # full regen braking, which is stronger than the braking that happens if
+      # you just reduce cruise speed.
+      if self._fast_decel_required(CS, lead_car) and self._no_human_action_for(milliseconds=500):
+        msg = "Off (Slow traffic)"
+        button = CruiseButtons.CANCEL
+        
       # if cruise is set to faster than the max speed, slow down
-      if CS.v_cruise_actual > self.acc_speed_kph:
+      elif CS.v_cruise_actual > self.acc_speed_kph and self._no_action_for(milliseconds=300):
         msg =  "Slow to max"
         button = CruiseButtons.DECEL_SET
-      # If lead_dist is reported as 0, no one is detected in front of you so you
-      # can speed up don't speed up when steer-angle > 2; vision radar often
-      # loses lead car in a turn.
-      elif lead_dist == 0 and self.enable_adaptive_cruise and CS.angle_steers < 2.0:
-        if full_press_kph < available_speed: 
-          msg =  "5 MPH UP   full: ","{0:.1f}kph".format(full_press_kph), "  avail: {0:.1f}kph".format(available_speed)
-          button = CruiseButtons.RES_ACCEL_2ND
-        elif half_press_kph < available_speed:
-          msg =  "1 MPH UP   half: ","{0:.1f}kph".format(half_press_kph), "  avail: {0:.1f}kph".format(available_speed)
-          button = CruiseButtons.RES_ACCEL
-
-      # if we have a populated lead_distance
-      elif (lead_dist > 0
-            # and we only issue commands every 300ms
-            and current_time_ms > self.automated_cruise_action_time + 300):
+        
+      elif (# if we have a populated lead_distance
+            lead_dist_m > 0
+            and self._no_action_for(milliseconds=300)
+            # and we're moving
+            and CS.v_cruise_actual > full_press_kph):
         ### Slowing down ###
-        # Reduce speed significantly if lead_dist < 50% of safe dist, no matter
-        # the rel_speed
-        if CS.v_cruise_actual > full_press_kph:
-          if lead_dist < (safe_dist_m * 0.3) and rel_speed < 2:
-            msg =  "50pct down"
-            button = CruiseButtons.DECEL_2ND
-          # Reduce speed significantly if lead_dist < 60% of  safe dist
-          # and if the lead car isn't pulling away
-          elif lead_dist < (safe_dist_m * 0.5) and rel_speed < 0:
-            msg =  "70pct down"
-            button = CruiseButtons.DECEL_SET
-           #Reduce speed if rel_speed < -15kph so you don't rush up to lead car
-          elif rel_speed < -15:
-            msg =  "relspd -15 down"
-            button = CruiseButtons.DECEL_SET
-          # we're close to the safe distance, so make slow adjustments
-          # only adjust every 1 secs
-          elif (lead_dist < (safe_dist_m * 0.9) and rel_speed < 0
-                and current_time_ms > self.automated_cruise_action_time + 1000):
-            msg =  "90pct down"
-            button = CruiseButtons.DECEL_SET
+        # Reduce speed significantly if lead_dist < safe dist
+        # and if the lead car isn't already pulling away.
+        if lead_dist_m < safe_dist_m * .5 and future_vrel_kph < 2:
+          msg =  "-5 (Significantly too close)"
+          button = CruiseButtons.DECEL_2ND
+        # Don't rush up to lead car
+        elif future_vrel_kph < -15:
+          msg =  "-5 (approaching too fast)"
+          button = CruiseButtons.DECEL_2ND
+        elif future_vrel_kph < -8:
+          msg =  "-1 (approaching too fast)"
+          button = CruiseButtons.DECEL_SET
+        elif lead_dist_m < safe_dist_m and future_vrel_kph <= 0:
+          msg =  "-1 (Too close)"
+          button = CruiseButtons.DECEL_SET
+        # Make slow adjustments if close to the safe distance.
+        # only adjust every 1 secs
+        elif (lead_dist_m < safe_dist_m * 1.3
+              and future_vrel_kph < -1 * half_press_kph
+              and self._no_action_for(milliseconds=1000)):
+          msg =  "-1 (Near safe distance)"
+          button = CruiseButtons.DECEL_SET
 
         ### Speed up ###
-        # don't speed up again until you have more than a safe distance in front
-        # only adjust every 2 sec
-        elif ((lead_dist > (safe_dist_m * 0.8) or rel_speed > 5) and half_press_kph < available_speed
-              and current_time_ms > self.automated_cruise_action_time + 100):
-          msg =  "120pct UP   half: ","{0:.1f}kph".format(half_press_kph), "  avail: {0:.1f}kph".format(available_speed)
+        elif (available_speed_kph > half_press_kph
+              and lead_dist_m > safe_dist_m
+              and self._no_human_action_for(milliseconds=1000)):
+          lead_is_far = lead_dist_m > safe_dist_m * 1.75
+          closing = future_vrel_kph < -2
+          lead_is_pulling_away = future_vrel_kph > 4
+          if lead_is_far and not closing or lead_is_pulling_away:
+            msg =  "+1 (Beyond safe distance and speed)"
+            button = CruiseButtons.RES_ACCEL
+          
+      # If lead_dist is reported as 0, no one is detected in front of you so you
+      # can speed up. Only accel on straight-aways; vision radar often
+      # loses lead car in a turn.
+      elif (lead_dist_m == 0
+            and CS.angle_steers < 2.0
+            and half_press_kph < available_speed_kph
+            and self._no_action_for(milliseconds=500)
+            and self._no_human_action_for(milliseconds=1000)
+            and current_time_ms > self.lead_last_seen_time_ms + 4000):
+          msg =  "+1 (road clear)"
           button = CruiseButtons.RES_ACCEL
-
-      # if we don't need to do any of the above, then we're at a pretty good
-      # speed make sure if we're at this point that the set cruise speed isn't
-      # set too low or high
-      if (cur_speed - CS.v_cruise_actual) > 5 and button == None:
-        # Send cruise stalk up_1st if the set speed is too low to bring it up
-        msg =  "cruise rectify"
-        button = CruiseButtons.RES_ACCEL
 
     if (current_time_ms > self.last_update_time + 1000):
       ratio = 0
       if safe_dist_m > 0:
-        ratio = (lead_dist / safe_dist_m) * 100
-      print "Ratio: {0:.1f}%".format(ratio), "   lead: ","{0:.1f}m".format(lead_dist),"   avail: ","{0:.1f}kph".format(available_speed), "   Rel Speed: ","{0:.1f}kph".format(rel_speed), "  Angle: {0:.1f}deg".format(CS.angle_steers)
+        ratio = (lead_dist_m / safe_dist_m) * 100
+      print "Ratio: {0:.1f}%  lead: {1:.1f}m  avail: {2:.1f}kph  vRel: {3:.1f}kph  Angle: {4:.1f}deg".format(
+        ratio, lead_dist_m, available_speed_kph, lead_car.vRel * CV.MS_TO_KPH, CS.angle_steers)
       self.last_update_time = current_time_ms
       if msg != None:
-        print msg
+        print "ACC: " + msg
         
     return button
+    
+  def _should_autoengage_cc(self, CS, lead_car=None):
+    # Automatically (re)engage cruise control so long as 
+    # 1) The carstate allows cruise control
+    # 2) There is no imminent threat of collision
+    # 3) The user did not cancel ACC by pressing the brake
+    cruise_ready = (self.enable_adaptive_cruise
+                    and CS.pcm_acc_status == CruiseState.STANDBY
+                    and CS.v_ego >= self.MIN_CRUISE_SPEED_MS
+                    and _current_time_millis() > self.fast_decel_time + 2000)
+                    
+    slow_lead = lead_car and lead_car.dRel > 0 and lead_car.vRel < 0 or self._fast_decel_required(CS, lead_car)
+    
+    # "Autoresume" mode allows cruise to engage even after brake events, but
+    # shouldn't trigger DURING braking.
+    autoresume_ready = self.autoresume and CS.a_ego >= 0.1
+    
+    braked = self.user_has_braked or self.has_gone_below_min_speed
+    
+    return cruise_ready and not slow_lead and (autoresume_ready or not braked)
+    
+  def _fast_decel_required(self, CS, lead_car):
+    """ Identifies situations which call for rapid deceleration. """
+    if not lead_car or not lead_car.dRel:
+      return False
+
+    collision_imminent = self._seconds_to_collision(CS, lead_car) < 4
+    
+    lead_absolute_speed_ms = lead_car.vRel + CS.v_ego
+    lead_too_slow = lead_absolute_speed_ms < self.MIN_CRUISE_SPEED_MS
+    
+    return collision_imminent or lead_too_slow
+    
+  def _seconds_to_collision(self, CS, lead_car):
+    if not lead_car or not lead_car.dRel:
+      return sys.maxint
+    elif lead_car.vRel >= 0:
+      return sys.maxint
+    return abs(float(lead_car.dRel) / lead_car.vRel)
+    
+  def _get_cc_units_kph(self, is_imperial_units):
+    # Cruise control buttons behave differently depending on whether the car
+    # is configured for metric or imperial units.
+    if is_imperial_units:
+      # Imperial unit cars adjust cruise in units of 1 and 5 mph.
+      half_press_kph = 1 * CV.MPH_TO_KPH
+      full_press_kph = 5 * CV.MPH_TO_KPH
+    else:
+      # Metric cars adjust cruise in units of 1 and 5 kph.
+      half_press_kph = 1
+      full_press_kph = 5
+    return half_press_kph, full_press_kph
+    
+  # Adjust speed based off OP's longitudinal model. As of OpenPilot 0.5.3, this
+  # is inoperable because the planner crashes when given only visual radar
+  # inputs. (Perhaps this can be used in the future with a radar install, or if
+  # OpenPilot planner changes.)
+  def _calc_button(self, CS, desired_speed_ms):
+    button_to_press = None
+    # Automatically engange traditional cruise if appropriate.
+    if self._should_autoengage_cc(CS) and desired_speed_ms >= CS.v_ego:
+      button_to_press = CruiseButtons.RES_ACCEL
+    # If traditional cruise is engaged, then control it.
+    elif (CS.pcm_acc_status == CruiseState.ENABLED
+          # But don't make adjustments if a human has manually done so in
+          # the last 3 seconds. Human intention should not be overridden.
+          and self._no_human_action_for(milliseconds=3000)
+          and self._no_automated_action_for(milliseconds=500)):
+      # The difference between OP's target speed and the current cruise
+      # control speed, in KPH.
+      speed_offset_kph = (desired_speed_ms * CV.MS_TO_KPH - CS.v_cruise_actual)
+    
+      half_press_kph, full_press_kph = self._get_cc_units_kph(CS.imperial_speed_units)
+      
+      # Reduce cruise speed significantly if necessary. Multiply by a % to
+      # make the car slightly more eager to slow down vs speed up.
+      if desired_speed_ms < self.MIN_CRUISE_SPEED_MS:
+        button_to_press = CruiseButtons.CANCEL
+      if speed_offset_kph < -2 * full_press_kph and CS.v_cruise_actual > 0:
+        button_to_press = CruiseButtons.CANCEL
+      elif speed_offset_kph < -0.6 * full_press_kph and CS.v_cruise_actual > 0:
+        # Send cruise stalk dn_2nd.
+        button_to_press = CruiseButtons.DECEL_2ND
+      # Reduce speed slightly if necessary.
+      elif speed_offset_kph < -0.9 * half_press_kph and CS.v_cruise_actual > 0:
+        # Send cruise stalk dn_1st.
+        button_to_press = CruiseButtons.DECEL_SET
+      # Increase cruise speed if possible.
+      elif CS.v_ego > self.MIN_CRUISE_SPEED_MS:
+        # How much we can accelerate without exceeding max allowed speed.
+        available_speed_kph = self.acc_speed_kph - CS.v_cruise_actual
+        if speed_offset_kph >= full_press_kph and full_press_kph < available_speed_kph:
+          # Send cruise stalk up_2nd.
+          button_to_press = CruiseButtons.RES_ACCEL_2ND
+        elif speed_offset_kph >= half_press_kph and half_press_kph < available_speed_kph:
+          # Send cruise stalk up_1st.
+          button_to_press = CruiseButtons.RES_ACCEL
+    return button_to_press
+    
+  def _no_human_action_for(self, milliseconds):
+    return _current_time_millis() > self.human_cruise_action_time + milliseconds
+    
+  def _no_automated_action_for(self, milliseconds):
+    return _current_time_millis() > self.automated_cruise_action_time + milliseconds
+    
+  def _no_action_for(self, milliseconds):
+    return self._no_human_action_for(milliseconds) and self._no_automated_action_for(milliseconds)

--- a/selfdrive/car/tesla/ACC_module.py
+++ b/selfdrive/car/tesla/ACC_module.py
@@ -46,7 +46,7 @@ class ACCMode(object):
       
   @ classmethod
   def get_labels(cls):
-    return [label for label in cls._label_to_mode if label != cls.OFF.label]
+    return [mode.label for mode in cls._all_modes]
 
 def _current_time_millis():
   return int(round(time.time() * 1000))

--- a/selfdrive/car/tesla/ACC_module.py
+++ b/selfdrive/car/tesla/ACC_module.py
@@ -170,6 +170,7 @@ class ACCController(object):
   # Decide which cruise control buttons to simluate to get the car to the
   # desired speed.
   def update_acc(self, enabled, CS, frame, actuators, pcm_speed):
+    print "Enter update_acc"
     # Adaptive cruise control
     current_time_ms = _current_time_millis()
     if CruiseButtons.should_be_throttled(CS.cruise_buttons):
@@ -212,6 +213,7 @@ class ACCController(object):
 
   # function to calculate the cruise button based on a safe follow distance
   def _calc_follow_button(self, CS, lead_car):
+    print "Enter _calc_follow_button"
     if lead_car is None:
       return None
     # Desired gap (in seconds) between cars.
@@ -313,6 +315,8 @@ class ACCController(object):
       if msg != None:
         print "ACC: " + msg
         
+    if button:
+      print "Cruise button: %s" % button
     return button
     
   def _should_autoengage_cc(self, CS, lead_car=None):

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -147,7 +147,6 @@ class PCCController(object):
     self.last_cruise_stalk_pull_time = 0
     self.prev_pcm_acc_status = 0
     self.prev_cruise_buttons = CruiseButtons.IDLE
-    self.prev_cruise_setting = CruiseButtons.IDLE
     self.pedal_hardware_present = False
     self.pedal_hardware_first_check = True
     self.pedal_speed_kph = 0.

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -218,17 +218,17 @@ class PCCController(object):
       self.user_pedal_state = CS.user_pedal_state
       CS.cstm_btns.set_button_status("pedal", 1 if self.user_pedal_state > 0 else 0)
       if self.user_pedal_state > 0:
-        CS.UE.custom_alert_message(3,"Pedal Interceptor Error (" + `self.user_pedal_state` + ")",150,4)
+        CS.UE.custom_alert_message(3, "Pedal Interceptor Error (%s)" % self.user_pedal_state, 150, 4)
         # send reset command
         idx = self.pedal_idx
         self.pedal_idx = (self.pedal_idx + 1) % 16
-        can_sends.append(teslacan.create_pedal_command_msg(0,0,idx))
+        can_sends.append(teslacan.create_pedal_command_msg(0, 0, idx))
         sendcan.send(can_list_to_can_capnp(can_sends, msgtype='sendcan').to_bytes())
     # disable on brake
     if CS.brake_pressed and self.enable_pedal_cruise:
       self.enable_pedal_cruise = False
       self.reset(0.)
-      CS.UE.custom_alert_message(3,"PDL Disabled",150,4)
+      CS.UE.custom_alert_message(3,"PDL Disabled", 150, 4)
       CS.cstm_btns.set_button_status("pedal",1)
       print "brake pressed"
 
@@ -251,9 +251,6 @@ class PCCController(object):
         self.LoC.reset(CS.v_ego)
         # Increase PCC speed to match current, if applicable.
         self.pedal_speed_kph = max(CS.v_ego * CV.MS_TO_KPH, self.pedal_speed_kph)
-      else:
-        # A single pull disables ACC (falling back to just steering).
-        self.enable_pedal_cruise = False
     # Handle pressing the cancel button.
     elif CS.cruise_buttons == CruiseButtons.CANCEL:
       self.enable_pedal_cruise = False
@@ -273,11 +270,10 @@ class PCCController(object):
         self.pedal_speed_kph = min(self.pedal_speed_kph, actual_speed_kph) - speed_uom_kph
       elif CS.cruise_buttons == CruiseButtons.DECEL_2ND:
         self.pedal_speed_kph = min(self.pedal_speed_kph, actual_speed_kph) - 5 * speed_uom_kph
-      # Clip ACC speed between 0 and 170 KPH.
-      self.pedal_speed_kph = clip(self.pedal_speed_kph,MIN_PCC_V ,MAX_PCC_V)
+      # Clip PCC speed between 0 and 170 KPH.
+      self.pedal_speed_kph = clip(self.pedal_speed_kph, MIN_PCC_V, MAX_PCC_V)
     # If something disabled cruise control, disable PCC too
-    elif (self.enable_pedal_cruise == True and
-          CS.pcm_acc_status != 0):
+    elif self.enable_pedal_cruise and CS.pcm_acc_status != 0:
       self.enable_pedal_cruise = False
     
     # Notify if PCC was toggled
@@ -290,8 +286,7 @@ class PCCController(object):
 
     # Update the UI to show whether the current car state allows PCC.
     if CS.cstm_btns.get_button_status("pedal") in [PCCState.STANDBY, PCCState.NOT_READY]:
-      if (enabled
-          and CruiseState.is_off(CS.pcm_acc_status)):
+      if enabled and CruiseState.is_off(CS.pcm_acc_status):
         CS.cstm_btns.set_button_status("pedal", PCCState.STANDBY)
       else:
         CS.cstm_btns.set_button_status("pedal", PCCState.NOT_READY)
@@ -301,12 +296,12 @@ class PCCController(object):
     self.prev_pcm_acc_status = CS.pcm_acc_status
     
 
-  def update_pdl(self,enabled,CS,frame,actuators,pcm_speed):
+  def update_pdl(self, enabled, CS, frame, actuators, pcm_speed):
     cur_time = sec_since_boot()
     idx = self.pedal_idx
     self.pedal_idx = (self.pedal_idx + 1) % 16
     if not self.pedal_hardware_present or not enabled:
-      return 0.,0,idx
+      return 0., 0, idx
     following = False
     # Alternative speed decision logic that uses the lead car's distance
     # and speed more directly.
@@ -340,7 +335,7 @@ class PCCController(object):
       #self.b_pid *= MPC_BRAKE_MULTIPLIER
 
 
-      enabled = ((self.LoC.long_control_state == LongCtrlState.pid) or (self.LoC.long_control_state == LongCtrlState.stopping)) and self.enable_pedal_cruise
+      enabled = self.enable_pedal_cruise and self.LoC.long_control_state in [LongCtrlState.pid, LongCtrlState.stopping]
 
       if self.enable_pedal_cruise: # enabled:
         accel_limits = map(float, calc_cruise_accel_limits(CS.v_ego, following))
@@ -374,7 +369,7 @@ class PCCController(object):
         # we will try to feed forward the pedal position.... we might want to feed the last output_gb....
         # it's all about testing now.
         aTarget = self.a_acc_sol
-        vTarget = clip(self.v_acc_sol,0,self.v_pid)
+        vTarget = clip(self.v_acc_sol, 0, self.v_pid)
         vTargetFuture = clip(vTargetFuture, 0, self.v_pid)
 
         t_go, t_brake = self.LoC.update(self.enable_pedal_cruise, CS.v_ego, CS.brake_pressed != 0, CS.standstill, False, 
@@ -408,7 +403,7 @@ class PCCController(object):
     ##############################################################
     elif (CS.cstm_btns.get_button_label2("pedal") == "Lng MPC"):
       self.b_pid = MPC_BRAKE_MULTIPLIER
-      output_gb = actuators.gas -  actuators.brake
+      output_gb = actuators.gas - actuators.brake
 
 
     ######################################################################################
@@ -416,7 +411,10 @@ class PCCController(object):
     #
     #save position for cruising (zero acc, zero brake, no torque) when we are above 10 MPH
     ######################################################################################
-    if (CS.torqueLevel < TORQUE_LEVEL_ACC) and (CS.torqueLevel > TORQUE_LEVEL_DECEL) and (CS.v_ego >= 10.* CV.MPH_TO_MS) and (abs(CS.torqueLevel) < abs(self.lastTorqueForPedalForZeroTorque)):
+    if (CS.torqueLevel < TORQUE_LEVEL_ACC
+        and CS.torqueLevel > TORQUE_LEVEL_DECEL
+        and CS.v_ego >= 10.* CV.MPH_TO_MS
+        and abs(CS.torqueLevel) < abs(self.lastTorqueForPedalForZeroTorque)):
       self.PedalForZeroTorque = self.prev_tesla_accel
       self.lastTorqueForPedalForZeroTorque = CS.torqueLevel
       #print "Detected new Pedal For Zero Torque at %s" % (self.PedalForZeroTorque)
@@ -437,8 +435,6 @@ class PCCController(object):
     tesla_accel = clip(apply_accel * MAX_PEDAL_VALUE,0,MAX_PEDAL_VALUE - tesla_brake)
     tesla_pedal = tesla_brake + tesla_accel
 
-
-
     tesla_pedal, self.accel_steady = accel_hysteresis(tesla_pedal, self.accel_steady, enabled)
     
     tesla_pedal = clip(tesla_pedal, self.prev_tesla_pedal - PEDAL_MAX_DOWN, self.prev_tesla_pedal + PEDAL_MAX_UP)
@@ -455,10 +451,8 @@ class PCCController(object):
 
     return self.prev_tesla_pedal,enable_pedal,idx
 
-
   # function to calculate the cruise speed based on a safe follow distance
   def calc_follow_speed(self, CS):
-    
     current_time_ms = _current_time_millis()
      # Make sure we were able to populate lead_1.
     if self.lead_1 is None:
@@ -479,7 +473,7 @@ class PCCController(object):
     msg = None
     msg2 = " *** UNKNOWN *** "
 
-    if ((self.last_md_ts == self.md_ts) or (self.last_l100_ts == self.l100_ts)):
+    if (self.last_md_ts == self.md_ts) or (self.last_l100_ts == self.l100_ts):
       #no radar update, so just keep doing what we're doing
       new_speed = self.last_speed
       new_brake = self.last_brake
@@ -487,7 +481,7 @@ class PCCController(object):
       if DEBUG:
         if msg:
           print msg
-        CS.UE.custom_alert_message(2,msg2+ " ["+ `int(new_speed*CV.KPH_TO_MPH)` + "]",6,0)
+        CS.UE.custom_alert_message(2, "%s [%s]" % (msg2, int(new_speed*CV.KPH_TO_MPH)), 6, 0)
       else:
         print msg2
       return new_speed * CV.KPH_TO_MS , new_brake
@@ -585,14 +579,14 @@ class PCCController(object):
         new_brake = 1.
         msg2 = msg
       #new_speed = clip(new_speed, 0, self.pedal_speed_kph)
-      new_speed = clip(new_speed,MIN_PCC_V,MAX_PCC_V)
+      new_speed = clip(new_speed, MIN_PCC_V, MAX_PCC_V)
       new_speed = clip(new_speed, 0, self.pedal_speed_kph)
       self.last_speed = new_speed
       self.last_brake = new_brake
       if DEBUG:
         if msg:
           print msg
-        CS.UE.custom_alert_message(2,msg2+ " ["+ `int(new_speed*CV.KPH_TO_MPH)` + "]",6,0)
+        CS.UE.custom_alert_message(2, "%s [%s]" % (msg2, int(new_speed*CV.KPH_TO_MPH)), 6, 0)
       else:
         print msg2
 

--- a/selfdrive/car/tesla/carcontroller.py
+++ b/selfdrive/car/tesla/carcontroller.py
@@ -237,7 +237,7 @@ class CarController(object):
       cruise_btn = None
       if self.ACC.enable_adaptive_cruise and not self.PCC.pedal_hardware_present:
         cruise_btn = self.ACC.update_acc(enabled, CS, frame, actuators, pcm_speed)
-      if (cruise_btn != None) or ((turn_signal_needed > 0) and (frame % 2 == 0)):
+      if cruise_btn or (turn_signal_needed > 0 and frame % 2 == 0):
           cruise_msg = teslacan.create_cruise_adjust_msg(
             spdCtrlLvr_stat=cruise_btn,
             turnIndLvr_Stat=turn_signal_needed,

--- a/selfdrive/car/tesla/carstate.py
+++ b/selfdrive/car/tesla/carstate.py
@@ -167,12 +167,12 @@ def get_epas_parser(CP):
 
 class CarState(object):
   def __init__(self, CP):
-    #labels for buttons
-    self.btns_init = [["alca","ALC",["MadMax","Normal","Wifey"]], \
-                      ["acc","ACC", ACCMode.get_labels()], \
-                      ["steer","STR",[""]], \
-                      ["brake","BRK",[""]], \
-                      ["msg", "MSG",[""]], \
+    # labels for buttons
+    self.btns_init = [["alca",  "ALC", ["MadMax", "Normal", "Wifey"]],
+                      ["acc",   "ACC", ACCMode.get_labels()],
+                      ["steer", "STR", [""]],
+                      ["brake", "BRK", [""]],
+                      ["msg",   "MSG", [""]],
                       ["sound", "SND", [""]]]
 
     if (CP.carFingerprint == CAR.MODELS):
@@ -302,24 +302,17 @@ class CarState(object):
     self.v_cruise_actual = 0.0
    
   def config_ui_buttons(self, pedalPresent):
-    hasChanges = False
     if pedalPresent:
-      btn = self.cstm_btns.get_button("acc")
-      if btn:
-        self.btns_init[1] = ["pedal", "PDL", ["Lng MPC", "Follow"]]
-        hasChanges = True
+      self.btns_init[1] = ["pedal", "PDL", ["Lng MPC", "Follow"]]
     else:
       # we don't have pedal interceptor
-      btn = self.cstm_btns.get_button("pedal")
-      if btn:
-        self.btns_init[1] = ["acc", "ACC", ACCMode.get_labels()]
-        hasChanges = True
-    if hasChanges:
-      btn.btn_name = self.btns_init[1][0]
-      btn.btn_label = self.btns_init[1][1]
-      btn.btn_label2 = self.btns_init[1][2][0]
-      btn.btn_status = 1
-      self.cstm_btns.update_ui_buttons(1, 1)    
+      self.btns_init[1] = ["acc", "ACC", ACCMode.get_labels()]
+    btn = self.cstm_btns.btns[1]
+    btn.btn_name = self.btns_init[1][0]
+    btn.btn_label = self.btns_init[1][1]
+    btn.btn_label2 = self.btns_init[1][2][0]
+    btn.btn_status = 1
+    self.cstm_btns.update_ui_buttons(1, 1)    
 
   def update(self, cp, epas_cp):
 

--- a/selfdrive/car/tesla/carstate.py
+++ b/selfdrive/car/tesla/carstate.py
@@ -2,6 +2,7 @@ from common.numpy_fast import interp
 from common.kalman.simple_kalman import KF1D
 from selfdrive.can.parser import CANParser
 from selfdrive.config import Conversions as CV
+from selfdrive.car.tesla.ACC_module import ACCMode
 from selfdrive.car.tesla.values import CAR, CruiseButtons, DBC
 from selfdrive.car.modules.UIBT_module import UIButtons,UIButton
 import numpy as np
@@ -168,7 +169,7 @@ class CarState(object):
   def __init__(self, CP):
     #labels for buttons
     self.btns_init = [["alca","ALC",["MadMax","Normal","Wifey"]], \
-                      ["acc","ACC",["Mod OP","Mod JJ"]], \
+                      ["acc","ACC", ACCMode.get_labels()], \
                       ["steer","STR",[""]], \
                       ["brake","BRK",[""]], \
                       ["msg", "MSG",[""]], \
@@ -325,7 +326,7 @@ class CarState(object):
       #we don't have pedal interceptor
       btn = self.cstm_btns.get_button("pedal")
       if btn:
-        self.btns_init[1] = ["acc","ACC",["Mod OP","Mod JJ"]]
+        self.btns_init[1] = ["acc", "ACC", ACCMode.get_labels()]
         hasChanges = True
     if hasChanges:
       i = 1

--- a/selfdrive/car/tesla/carstate.py
+++ b/selfdrive/car/tesla/carstate.py
@@ -421,7 +421,7 @@ class CarState(object):
     #BB this is a hack for the interceptor
     self.pedal_hardware_present_prev = self.pedal_hardware_present
     # For now, use ACC if cruise is ready, and pedal interception otherwise.
-    self.pedal_hardware_present = bool(self.pcm_acc_status)
+    self.pedal_hardware_present = not bool(self.pcm_acc_status)
     if self.pedal_hardware_present != self.pedal_hardware_present_prev:
         self.config_ui_buttons(self.pedal_hardware_present)
 

--- a/selfdrive/car/tesla/interface.py
+++ b/selfdrive/car/tesla/interface.py
@@ -277,13 +277,10 @@ class CarInterface(object):
         be.type = 'altButton3'
       buttonEvents.append(be)
 
-    if self.CS.cruise_setting != self.CS.prev_cruise_setting:
+    if self.CS.cruise_buttons != self.CS.prev_cruise_buttons:
       be = car.CarState.ButtonEvent.new_message()
       be.type = 'unknown'
-      if self.CS.cruise_setting != 0:
-        be.pressed = True
-      else:
-        be.pressed = False
+      be.pressed = bool(self.CS.cruise_buttons)
       buttonEvents.append(be)
     ret.buttonEvents = buttonEvents
 


### PR DESCRIPTION
When cruise stalk is enabled (light on) then ACC button appear on screen. When cruise stalk is disabled (light off) then PCC button appears on screen. This is a hacky solution until we get code that can detect the presence of the Pedal board.

Also merges in latest ACC code.