### PR TITLE
Add pedal detection, add experimental 'devel' PCC mode

### DIFF
--- a/selfdrive/car/tesla/ACC_module.py
+++ b/selfdrive/car/tesla/ACC_module.py
@@ -170,7 +170,6 @@ class ACCController(object):
   # Decide which cruise control buttons to simluate to get the car to the
   # desired speed.
   def update_acc(self, enabled, CS, frame, actuators, pcm_speed):
-    print "Enter update_acc"
     # Adaptive cruise control
     current_time_ms = _current_time_millis()
     if CruiseButtons.should_be_throttled(CS.cruise_buttons):
@@ -213,7 +212,6 @@ class ACCController(object):
 
   # function to calculate the cruise button based on a safe follow distance
   def _calc_follow_button(self, CS, lead_car):
-    print "Enter _calc_follow_button"
     if lead_car is None:
       return None
     # Desired gap (in seconds) between cars.
@@ -314,9 +312,6 @@ class ACCController(object):
       self.last_update_time = current_time_ms
       if msg != None:
         print "ACC: " + msg
-        
-    if button:
-      print "Cruise button: %s" % button
     return button
     
   def _should_autoengage_cc(self, CS, lead_car=None):

--- a/selfdrive/car/tesla/ACC_module.py
+++ b/selfdrive/car/tesla/ACC_module.py
@@ -45,7 +45,7 @@ class ACCMode(object):
     return cls._label_to_mode.get(label, cls.OFF)  # Default to OFF.
       
   @ classmethod
-  def get_labels(cls):
+  def labels(cls):
     return [mode.label for mode in cls._all_modes]
 
 def _current_time_millis():

--- a/selfdrive/car/tesla/ACC_module.py
+++ b/selfdrive/car/tesla/ACC_module.py
@@ -33,6 +33,9 @@ class ACCMode(object):
   ON   = _Mode(label="on",   autoresume=False, state=ACCState.STANDBY)
   AUTO = _Mode(label="auto", autoresume=True,  state=ACCState.STANDBY)
   
+  BUTTON_NAME = 'acc'
+  BUTTON_ABREVIATION = 'ACC'
+  
   # Toggle order: OFF -> ON -> AUTO -> OFF
   _all_modes = [OFF, ON, AUTO]
   for index, mode in enumerate(_all_modes):
@@ -86,9 +89,9 @@ class ACCController(object):
     # cruise control should be enabled. Twice in .75 seconds counts as a double
     # pull.
     self.prev_enable_adaptive_cruise = self.enable_adaptive_cruise
-    acc_string = CS.cstm_btns.get_button_label2("acc")
+    acc_string = CS.cstm_btns.get_button_label2(ACCMode.BUTTON_NAME)
     acc_mode = ACCMode.from_label(acc_string)
-    CS.cstm_btns.get_button("acc").btn_label2 = acc_mode.label
+    CS.cstm_btns.get_button(ACCMode.BUTTON_NAME).btn_label2 = acc_mode.label
     self.autoresume = acc_mode.autoresume
     curr_time_ms = _current_time_millis()
     # Handle pressing the enable button.
@@ -96,7 +99,7 @@ class ACCController(object):
         self.prev_cruise_buttons != CruiseButtons.MAIN):
       double_pull = curr_time_ms - self.last_cruise_stalk_pull_time < 750
       self.last_cruise_stalk_pull_time = curr_time_ms
-      ready = (CS.cstm_btns.get_button_status("acc") > ACCState.OFF
+      ready = (CS.cstm_btns.get_button_status(ACCMode.BUTTON_NAME) > ACCState.OFF
                and enabled
                and CruiseState.is_enabled_or_standby(CS.pcm_acc_status)
                and CS.v_ego > self.MIN_CRUISE_SPEED_MS)
@@ -133,20 +136,20 @@ class ACCController(object):
     # Notify if ACC was toggled
     if self.prev_enable_adaptive_cruise and not self.enable_adaptive_cruise:
       CS.UE.custom_alert_message(3, "ACC Disabled", 150, 4)
-      CS.cstm_btns.set_button_status("acc", ACCState.STANDBY)
+      CS.cstm_btns.set_button_status(ACCMode.BUTTON_NAME, ACCState.STANDBY)
     elif self.enable_adaptive_cruise:
-      CS.cstm_btns.set_button_status("acc", ACCState.ENABLED)
+      CS.cstm_btns.set_button_status(ACCMode.BUTTON_NAME, ACCState.ENABLED)
       if not self.prev_enable_adaptive_cruise:
         CS.UE.custom_alert_message(2, "ACC Enabled", 150)
 
     # Update the UI to show whether the current car state allows ACC.
-    if CS.cstm_btns.get_button_status("acc") in [ACCState.STANDBY, ACCState.NOT_READY]:
+    if CS.cstm_btns.get_button_status(ACCMode.BUTTON_NAME) in [ACCState.STANDBY, ACCState.NOT_READY]:
       if (enabled
           and CruiseState.is_enabled_or_standby(CS.pcm_acc_status)
           and CS.v_ego > self.MIN_CRUISE_SPEED_MS):
-        CS.cstm_btns.set_button_status("acc", ACCState.STANDBY)
+        CS.cstm_btns.set_button_status(ACCMode.BUTTON_NAME, ACCState.STANDBY)
       else:
-        CS.cstm_btns.set_button_status("acc", ACCState.NOT_READY)
+        CS.cstm_btns.set_button_status(ACCMode.BUTTON_NAME, ACCState.NOT_READY)
           
     # Update prev state after all other actions.
     self.prev_cruise_buttons = CS.cruise_buttons
@@ -182,7 +185,7 @@ class ACCController(object):
       button_to_press = CruiseButtons.CANCEL
 
     if self.enable_adaptive_cruise and enabled:
-      if CS.cstm_btns.get_button_label2("acc") in ["OP", "AutoOP"]:    
+      if CS.cstm_btns.get_button_label2(ACCMode.BUTTON_NAME) in ["OP", "AutoOP"]:    
         button_to_press = self._calc_button(CS, pcm_speed)
       else:
         # Alternative speed decision logic that uses the lead car's distance

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -448,26 +448,19 @@ class PCCController(object):
     elif PCCModes.button_is(ExperimentalMode(), CS.cstm_btns):
       output_gb = 0.0
       if enabled and self.enable_pedal_cruise:
-        self.b_pid = MPC_BRAKE_MULTIPLIER
-        
-        MAX_ACCEL_RATIO = 1.1
+        MAX_ACCEL_RATIO = 1.07
         MIN_ACCEL_RATIO = 0.8
-        #MIN_PEDAL_ACCEL_POSITION = 0.05
-        
+        self.b_pid = MPC_BRAKE_MULTIPLIER 
         optimal_dist_m = _safe_distance_m(CS.v_ego)
-
         available_speed_kph = self.pedal_speed_kph - CS.v_ego * CV.MS_TO_KPH
+        # if going above the max configured PCC speed, slow.
         if available_speed_kph < 0 and _distance_is_safe(CS.v_ego, self.lead_1):
-          # linearly brake harder, getting up to -1 at 5kph over
-          output_gb = available_speed_kph / 5.0
+          # linearly brake harder, getting up to -1 at 8kph over
+          output_gb = max(available_speed_kph, -8) / 8.0
           print 'Expr PCC: %s' % output_gb
           print '(%s-%s=%s kph over limit)' % (self.pedal_speed_kph, CS.v_ego * CV.MS_TO_KPH, available_speed_kph)
-        #elif self.LoC.long_control_state not in [LongCtrlState.pid, LongCtrlState.stopping]:
-        #  self.LoC.reset(CS.v_ego)
-        #  print "PID reset"
-        #  enabled = False
-        # Hold speed in turns if no car is too close
-        elif CS.angle_steers >= 5.0 and _distance_is_safe(CS.v_ego, self.lead_1):
+        # Hold speed in turns if no car is seen
+        elif CS.angle_steers >= 5.0 and not (self.lead_1 or self.lead_1.dRel):
           print 'EXPR PCC: %s (in a turn)' % output_gb
           pass
         # Try to stay 2 seconds behind lead, matching their speed.
@@ -479,21 +472,16 @@ class PCCController(object):
           velocity_ratio = lead_absolute_velocity_ms / max(CS.v_ego, 0.001)
           velocity_ratio = clip(velocity_ratio, MIN_ACCEL_RATIO, MAX_ACCEL_RATIO)
           
-          #pedal_position = (distance_ratio *  velocity_ratio) * self.prev_tesla_pedal
-          #pedal_position = clip(pedal_position, 0.0, MAX_PEDAL_VALUE)
-          #if distance_ratio > 1 and velocity_ratio > 1:
-          #  pedal_position = max(pedal_position, MIN_PEDAL_ACCEL_POSITION)
-    
-          # Pedal position goes from 0 to MAX_PEDAL_VALUE. Rescale from -1 to 1.
-          #output_gb = float(pedal_position * 2 - MAX_PEDAL_VALUE) / MAX_PEDAL_VALUE
-          net_ratio = distance_ratio * velocity_ratio
+          # Weigh the velocity less than the distance
+          net_ratio = distance_ratio * (velocity_ratio ** 0.7)
+
           # rescale around 0 rather than 1.
           output_gb = net_ratio - 1
           print 'EXPR PCC: %s (following)' % output_gb
         # If no lead has been seen for a few seconds, accelerate.
         elif _current_time_millis() > self.lead_last_seen_time_ms + 3000:
           linear_factor = min(available_speed_kph, 5) / 5
-          output_gb = 0.2 * linear_factor
+          output_gb = 0.15 * linear_factor
           print 'EXPR PCC: %s (all clear)' % output_gb
         else:
           print 'EXPER PCC: NOTHING?'

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -450,9 +450,9 @@ class PCCController(object):
       if enabled and self.enable_pedal_cruise:
         self.b_pid = MPC_BRAKE_MULTIPLIER
         
-        MAX_ACCEL_RATIO = 1.01
+        MAX_ACCEL_RATIO = 1.1
         MIN_ACCEL_RATIO = 0.8
-        MIN_PEDAL_ACCEL_POSITION = 0.05
+        #MIN_PEDAL_ACCEL_POSITION = 0.05
         
         optimal_dist_m = max(CS.v_ego * 2, MIN_SAFE_DIST_M)
 
@@ -479,13 +479,16 @@ class PCCController(object):
           velocity_ratio = lead_absolute_velocity_ms / max(CS.v_ego, 0.001)
           velocity_ratio = clip(velocity_ratio, MIN_ACCEL_RATIO, MAX_ACCEL_RATIO)
           
-          pedal_position = (distance_ratio *  velocity_ratio) * self.prev_tesla_pedal
-          pedal_position = clip(pedal_position, 0.0, MAX_PEDAL_VALUE)
-          if distance_ratio > 1 and velocity_ratio > 1:
-            pedal_position = max(pedal_position, MIN_PEDAL_ACCEL_POSITION)
+          #pedal_position = (distance_ratio *  velocity_ratio) * self.prev_tesla_pedal
+          #pedal_position = clip(pedal_position, 0.0, MAX_PEDAL_VALUE)
+          #if distance_ratio > 1 and velocity_ratio > 1:
+          #  pedal_position = max(pedal_position, MIN_PEDAL_ACCEL_POSITION)
     
           # Pedal position goes from 0 to MAX_PEDAL_VALUE. Rescale from -1 to 1.
-          output_gb = float(pedal_position * 2 - MAX_PEDAL_VALUE) / MAX_PEDAL_VALUE
+          #output_gb = float(pedal_position * 2 - MAX_PEDAL_VALUE) / MAX_PEDAL_VALUE
+          net_ratio = distance_ratio * velocity_ratio
+          # rescale around 0 rather than 1.
+          output_gb = net_ratio - 1
           print 'EXPR PCC: %s (following)' % output_gb
         # If no lead has been seen for a few seconds, accelerate.
         elif _current_time_millis() > self.lead_last_seen_time_ms + 3000:

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -94,7 +94,7 @@ class FollowMode(Mode):
 class ExperimentalMode(Mode):
   label = 'EXPRMNT'
   
-class Modes(object):
+class PCCModes(object):
   _all_modes = [OffMode(), OpMode(), FollowMode(), ExperimentalMode()]
   _mode_map = {mode.label : mode for mode in _all_modes}
   
@@ -365,7 +365,7 @@ class PCCController(object):
     # once the speed is detected we have to use our own PID to determine
     # how much accel and break we have to do
     ####################################################################
-    if Modes.button_is(FollowMode(), CS.cstm_btns):
+    if PCCModes.button_is(FollowMode(), CS.cstm_btns):
       self.v_pid, self.b_pid = self.calc_follow_speed(CS)
       # cruise speed can't be negative even is user is distracted
       self.v_pid = max(self.v_pid, 0.)
@@ -436,7 +436,7 @@ class PCCController(object):
     #
     # we use the values from actuator.accel and actuator.brake
     ##############################################################
-    elif Modes.button_is(OpMode(), CS.cstm_btns):
+    elif PCCModes.button_is(OpMode(), CS.cstm_btns):
       self.b_pid = MPC_BRAKE_MULTIPLIER
       output_gb = actuators.gas - actuators.brake
 
@@ -445,7 +445,7 @@ class PCCController(object):
     #
     # Don't use it.
     ##############################################################
-    elif Modes.button_is(ExperimentalMode(), CS.cstm_btns):
+    elif PCCModes.button_is(ExperimentalMode(), CS.cstm_btns):
       output_gb = 0.0
       if enabled and self.enable_pedal_cruise:
         self.b_pid = MPC_BRAKE_MULTIPLIER

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -468,11 +468,11 @@ class PCCController(object):
         elif CS.angle_steers >= 5.0 and _distance_is_safe(CS.v_ego, self.lead_1):
           pass
         # Try to stay 2 seconds behind lead, matching their speed.
-        elif self.lead_1 and self.lead_1.d_rel:
-          distance_ratio = self.lead_1.d_rel / optimal_dist_m or MAX_ACCEL_RATIO
+        elif self.lead_1 and self.lead_1.dRel:
+          distance_ratio = self.lead_1.dRel / optimal_dist_m or MAX_ACCEL_RATIO
           distance_ratio = clip(distance_ratio, MIN_ACCEL_RATIO, MAX_ACCEL_RATIO)
           
-          lead_absolute_velocity_ms = CS.v_ego + self.lead_1.v_rel
+          lead_absolute_velocity_ms = CS.v_ego + self.lead_1.vRel
           velocity_ratio = lead_absolute_velocity_ms / max(CS.v_ego, 0.001)
           velocity_ratio = clip(velocity_ratio, MIN_ACCEL_RATIO, MAX_ACCEL_RATIO)
           
@@ -675,5 +675,5 @@ def _safe_distance_m(v_ms):
   return max(FOLLOW_TIME_S * v_ms, MIN_SAFE_DIST_M)
   
 def _distance_is_safe(v_ego_ms, lead):
-  lead_too_close = bool(lead and lead.d_rel and lead.d_rel <= _safe_distance_m(v_ego_ms))
+  lead_too_close = bool(lead and lead.dRel and lead.dRel <= _safe_distance_m(v_ego_ms))
   return not lead_too_close

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -97,6 +97,8 @@ class ExperimentalMode(Mode):
 class PCCModes(object):
   _all_modes = [OffMode(), OpMode(), FollowMode(), ExperimentalMode()]
   _mode_map = {mode.label : mode for mode in _all_modes}
+  BUTTON_NAME = 'pedal'
+  BUTTON_ABREVIATION = 'PDL'
   
   @classmethod
   def from_label(cls, label):
@@ -104,10 +106,11 @@ class PCCModes(object):
     
   @classmethod
   def from_buttons(cls, cstm_btns):
-    return cls.from_label(cstm_btns.get_button_label2("pedal"))
+    return cls.from_label(cstm_btns.get_button_label2(cls.BUTTON_NAME))
     
   @classmethod
-  def button_is(cls, mode, cstm_butns):
+  def is_selected(cls, mode, cstm_butns):
+    """Tell if the UI buttons are set to the given mode"""
     return type(mode) == type(cls.from_buttons(cstm_butns))
     
   @classmethod
@@ -365,7 +368,7 @@ class PCCController(object):
     # once the speed is detected we have to use our own PID to determine
     # how much accel and break we have to do
     ####################################################################
-    if PCCModes.button_is(FollowMode(), CS.cstm_btns):
+    if PCCModes.is_selected(FollowMode(), CS.cstm_btns):
       self.v_pid, self.b_pid = self.calc_follow_speed(CS)
       # cruise speed can't be negative even is user is distracted
       self.v_pid = max(self.v_pid, 0.)
@@ -436,7 +439,7 @@ class PCCController(object):
     #
     # we use the values from actuator.accel and actuator.brake
     ##############################################################
-    elif PCCModes.button_is(OpMode(), CS.cstm_btns):
+    elif PCCModes.is_selected(OpMode(), CS.cstm_btns):
       self.b_pid = MPC_BRAKE_MULTIPLIER
       output_gb = actuators.gas - actuators.brake
 
@@ -445,7 +448,7 @@ class PCCController(object):
     #
     # Don't use it.
     ##############################################################
-    elif PCCModes.button_is(ExperimentalMode(), CS.cstm_btns):
+    elif PCCModes.is_selected(ExperimentalMode(), CS.cstm_btns):
       output_gb = 0.0
       if enabled and self.enable_pedal_cruise:
         MAX_ACCEL_RATIO = 1.07

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -455,7 +455,7 @@ class PCCController(object):
     elif PCCModes.is_selected(ExperimentalMode(), CS.cstm_btns):
       output_gb = 0.0
       if enabled and self.enable_pedal_cruise:
-        MAX_ACCEL_RATIO = 1.07
+        MAX_ACCEL_RATIO = 1.09
         MIN_ACCEL_RATIO = 0.7
         self.b_pid = MPC_BRAKE_MULTIPLIER 
         optimal_dist_m = _safe_distance_m(CS.v_ego)
@@ -489,8 +489,8 @@ class PCCController(object):
           
           net_ratio = distance_ratio * (velocity_ratio ** v_weight)
           # Don't accelerate based on intermittent sightings
-          if self.continuous_lead_sightings < 10:
-            net_ratio = min(net_ratio, 1.0)
+          #if self.continuous_lead_sightings < 3:
+          #  net_ratio = min(net_ratio, 1.0)
             
           # rescale around 0 rather than 1.
           output_gb = net_ratio - 1
@@ -503,7 +503,7 @@ class PCCController(object):
         # If no lead has been seen for a few seconds, accelerate.
         elif _current_time_millis() > self.lead_last_seen_time_ms + 3000:
           linear_factor = min(available_speed_kph, 5) / 5
-          output_gb = 0.15 * linear_factor
+          output_gb = 0.12 * linear_factor
 
     ######################################################################################
     # Determine pedal "zero"
@@ -698,4 +698,7 @@ def _is_present(lead):
   return bool(lead and lead.dRel)
 
 def _sec_til_collision(lead):
-  return lead.dRel / lead.vRel
+  if _is_present(lead) and lead.vRel != 0:
+    return lead.dRel / lead.vRel
+  else:
+    return 60  # Arbitrary, but better than MAXINT because we can still do math on it.

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -339,7 +339,7 @@ class PCCController(object):
     # once the speed is detected we have to use our own PID to determine
     # how much accel and break we have to do
     ####################################################################
-    if (CS.cstm_btns.get_button_label2_index("pedal") == 1):
+    if CS.cstm_btns.get_button_label2("pedal") == "Follow":
       self.v_pid, self.b_pid = self.calc_follow_speed(CS)
       # cruise speed can't be negative even is user is distracted
       self.v_pid = max(self.v_pid, 0.)
@@ -349,7 +349,7 @@ class PCCController(object):
       enabled = self.enable_pedal_cruise and self.LoC.long_control_state in [LongCtrlState.pid, LongCtrlState.stopping]
 
       if self.enable_pedal_cruise:
-        accel_min, accel_max = calc_cruise_accel_limits(CS.v_ego, following)
+        accel_min, accel_max = calc_cruise_accel_limits(CS, following)
         # TODO: make a separate lookup for jerk tuning
         jerk_min = min(-0.1, accel_min)
         jerk_max = max(0.1, accel_max)
@@ -442,8 +442,8 @@ class PCCController(object):
     pedal_zero = 0.
     if CS.v_ego >= 5.* CV.MPH_TO_MS:
       pedal_zero = self.PedalForZeroTorque
-    tesla_brake = clip((1. - apply_brake) * pedal_zero,0,pedal_zero)
-    tesla_accel = clip(apply_accel * MAX_PEDAL_VALUE,0,MAX_PEDAL_VALUE - tesla_brake)
+    tesla_brake = clip((1. - apply_brake) * pedal_zero, 0, pedal_zero)
+    tesla_accel = clip(apply_accel * MAX_PEDAL_VALUE, 0, MAX_PEDAL_VALUE - tesla_brake)
     tesla_pedal = tesla_brake + tesla_accel
 
     tesla_pedal, self.accel_steady = accel_hysteresis(tesla_pedal, self.accel_steady, enabled)
@@ -460,7 +460,7 @@ class PCCController(object):
     self.last_md_ts = self.md_ts
     self.last_l100_ts = self.l100_ts
 
-    return self.prev_tesla_pedal,enable_pedal,idx
+    return self.prev_tesla_pedal, enable_pedal, idx
 
   # function to calculate the cruise speed based on a safe follow distance
   def calc_follow_speed(self, CS):

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -457,11 +457,8 @@ class PCCController(object):
         if available_speed_kph < 0 and _distance_is_safe(CS.v_ego, self.lead_1):
           # linearly brake harder, getting up to -1 at 8kph over
           output_gb = max(available_speed_kph, -8) / 8.0
-          print 'Expr PCC: %s' % output_gb
-          print '(%s-%s=%s kph over limit)' % (self.pedal_speed_kph, CS.v_ego * CV.MS_TO_KPH, available_speed_kph)
         # Hold speed in turns if no car is seen
         elif CS.angle_steers >= 5.0 and not (self.lead_1 or self.lead_1.dRel):
-          print 'EXPR PCC: %s (in a turn)' % output_gb
           pass
         # Try to stay 2 seconds behind lead, matching their speed.
         elif self.lead_1 and self.lead_1.dRel:
@@ -477,15 +474,10 @@ class PCCController(object):
 
           # rescale around 0 rather than 1.
           output_gb = net_ratio - 1
-          print 'EXPR PCC: %s (following)' % output_gb
         # If no lead has been seen for a few seconds, accelerate.
         elif _current_time_millis() > self.lead_last_seen_time_ms + 3000:
           linear_factor = min(available_speed_kph, 5) / 5
           output_gb = 0.15 * linear_factor
-          print 'EXPR PCC: %s (all clear)' % output_gb
-        else:
-          print 'EXPER PCC: NOTHING?'
-
 
     ######################################################################################
     # Determine pedal "zero"

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -493,7 +493,7 @@ class PCCController(object):
           velocity_ratio = clip(velocity_ratio, MAX_DECEL_RATIO, MAX_ACCEL_RATIO)
           # Discount speed reading if the time til potential collision is great.
           # This accounts for poor visual radar at distances. It also means that
-          # at very low speed, 
+          # at very low speed, distance logic dominates.
           v_weights = OrderedDict([
             # seconds to cross distance : importance of relative speed
             (FOLLOW_TIME_S,        1.),
@@ -501,8 +501,7 @@ class PCCController(object):
             (FOLLOW_TIME_S * 5,    0.),  # zero weight when distant
             (FOLLOW_TIME_S * 6,    0.)
           ])
-          # TODO: decide better logic at v=0
-          v_weight = interp(_sec_to_travel(self.lead_1.dRel, CS.v_ego) or 0, v_weights.keys(), v_weights.values())
+          v_weight = interp(_sec_to_travel(self.lead_1.dRel, CS.v_ego) or 60, v_weights.keys(), v_weights.values())
           weighted_v_ratio = velocity_ratio ** v_weight
          
           gb_ratio = weighted_d_ratio * weighted_v_ratio

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -449,7 +449,7 @@ class PCCController(object):
       output_gb = 0.0
       if enabled and self.enable_pedal_cruise:
         MAX_ACCEL_RATIO = 1.07
-        MIN_ACCEL_RATIO = 0.8
+        MIN_ACCEL_RATIO = 0.7
         self.b_pid = MPC_BRAKE_MULTIPLIER 
         optimal_dist_m = _safe_distance_m(CS.v_ego)
         available_speed_kph = self.pedal_speed_kph - CS.v_ego * CV.MS_TO_KPH

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -405,7 +405,7 @@ class PCCController(object):
         # we will try to feed forward the pedal position.... we might want to feed the last output_gb....
         # it's all about testing now.
         vTarget = clip(self.v_acc_sol, 0, self.v_pid)
-        self.vTargetFuture = clip(self.vTargetFuture, 0, self.v_pid)
+        self.vTargetFuture = clip(self.v_acc_future, 0, self.v_pid)
 
         t_go, t_brake = self.LoC.update(self.enable_pedal_cruise, CS.v_ego, CS.brake_pressed != 0, CS.standstill, False, 
                   self.v_pid , vTarget, self.vTargetFuture, self.a_acc_sol, CS.CP, None)

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -487,11 +487,12 @@ class PCCController(object):
           time_factor = (_current_time_millis() - self.lead_last_seen_time_ms - 2000) / 4000
           time_factor = clip(time_factor, 0, 1)
           output_gb = 0.12 * max_speed_factor * time_factor
-        # if going above the max configured PCC speed, slow.
+        # If going above the max configured PCC speed, slow. This should always
+        # be in force so it is not part of the if/else block above.
         if available_speed_kph < 0:
           # linearly brake harder, hitting -1 at 10kph over
           speed_limited_gb = max(available_speed_kph, -10) / 10.0
-          # Brake at least this hard.
+          # This is a minimum braking amount. The logic above may ask for more.
           output_gb = min(output_gb, speed_limited_gb)
 
     ######################################################################################

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -514,11 +514,12 @@ class PCCController(object):
             # linearly brake harder, hitting -1 at 10kph over
             speed_limited_gb = max(available_speed_kph, -10) / 10.0
             output_gb = min(output_gb, speed_limited_gb)
-        # If no lead has been seen for a few seconds, accelerate.
-        elif _current_time_millis() > self.lead_last_seen_time_ms + 3000:
-          # TODO: scale based on how long since sighting
-          linear_factor = min(available_speed_kph, 5) / 5
-          output_gb = 0.12 * linear_factor
+        # If no lead has been seen for a few seconds, accelerate to max speed.
+        elif _current_time_millis() > self.lead_last_seen_time_ms + 2000:
+          max_speed_factor = min(available_speed_kph, 5) / 5  # 0 near max speed
+          time_factor = (_current_time_millis() - self.lead_last_seen_time_ms - 2000) / 4000
+          time_factor = clip(time_factor, 0, 1)
+          output_gb = 0.12 * max_speed_factor * time_factor
 
     ######################################################################################
     # Determine pedal "zero"

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -485,7 +485,7 @@ class PCCController(object):
             (10., 0.),
             (16., 0.)
           ])
-          v_weight = interp(_sec_til_collision(self.lead), v_weights.keys(), v_weights.vakues())
+          v_weight = interp(_sec_til_collision(self.lead_1), v_weights.keys(), v_weights.values())
           
           net_ratio = distance_ratio * (velocity_ratio ** v_weight)
           # Don't accelerate based on intermittent sightings

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -454,7 +454,7 @@ class PCCController(object):
         MIN_ACCEL_RATIO = 0.8
         #MIN_PEDAL_ACCEL_POSITION = 0.05
         
-        optimal_dist_m = max(CS.v_ego * 2, MIN_SAFE_DIST_M)
+        optimal_dist_m = _safe_distance_m(CS.v_ego)
 
         available_speed_kph = self.pedal_speed_kph - CS.v_ego * CV.MS_TO_KPH
         if available_speed_kph < 0 and _distance_is_safe(CS.v_ego, self.lead_1):

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -460,10 +460,10 @@ class PCCController(object):
         if available_speed_kph < 0 and _distance_is_safe(CS.v_ego, self.lead_1):
           # linearly brake harder, getting up to -1 at 5kph over
           output_gb = available_speed_kph / 5.0
-        elif self.LoC.long_control_state not in [LongCtrlState.pid, LongCtrlState.stopping]:
-          self.LoC.reset(CS.v_ego)
-          print "PID reset"
-          enabled = False
+        #elif self.LoC.long_control_state not in [LongCtrlState.pid, LongCtrlState.stopping]:
+        #  self.LoC.reset(CS.v_ego)
+        #  print "PID reset"
+        #  enabled = False
         # Hold speed in turns if no car is too close
         elif CS.angle_steers >= 5.0 and _distance_is_safe(CS.v_ego, self.lead_1):
           pass
@@ -484,7 +484,7 @@ class PCCController(object):
           # Pedal position goes from 0 to 1. Rescale from -1 to 1.
           output_gb = pedal_position * 2 - 1
         # If no lead has been seen for a few seconds, accelerate.
-        elif _current_time_millis() > self.lead_last_seen_time_ms() + 3000:
+        elif _current_time_millis() > self.lead_last_seen_time_ms + 3000:
           linear_factor = min(available_speed_kph, 10) / 10
           output_gb = 0.2 * linear_factor
 

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -480,12 +480,12 @@ class PCCController(object):
           velocity_ratio = clip(velocity_ratio, MIN_ACCEL_RATIO, MAX_ACCEL_RATIO)
           
           pedal_position = (distance_ratio *  velocity_ratio) * self.prev_tesla_pedal
-          pedal_position = clip(pedal_position, 0.0 , 1.0)
+          pedal_position = clip(pedal_position, 0.0, MAX_PEDAL_VALUE)
           if distance_ratio > 1 and velocity_ratio > 1:
             pedal_position = max(pedal_position, MIN_PEDAL_ACCEL_POSITION)
     
-          # Pedal position goes from 0 to 1. Rescale from -1 to 1.
-          output_gb = pedal_position * 2 - 1
+          # Pedal position goes from 0 to MAX_PEDAL_VALUE. Rescale from -1 to 1.
+          output_gb = float(pedal_position * 2 - MAX_PEDAL_VALUE) / MAX_PEDAL_VALUE
           print 'EXPR PCC: %s (following)' % output_gb
         # If no lead has been seen for a few seconds, accelerate.
         elif _current_time_millis() > self.lead_last_seen_time_ms + 3000:

--- a/selfdrive/car/tesla/carstate.py
+++ b/selfdrive/car/tesla/carstate.py
@@ -169,12 +169,12 @@ def get_epas_parser(CP):
 class CarState(object):
   def __init__(self, CP):
     # labels for buttons
-    self.btns_init = [["alca",  "ALC", ["MadMax", "Normal", "Wifey"]],
-                      ["acc",   "ACC", ACCMode.labels()],
-                      ["steer", "STR", [""]],
-                      ["brake", "BRK", [""]],
-                      ["msg",   "MSG", [""]],
-                      ["sound", "SND", [""]]]
+    self.btns_init = [["alca",                "ALC",                      ["MadMax", "Normal", "Wifey"]],
+                      [ACCMode.BUTTON_NAME,   ACCMode.BUTTON_ABREVIATION, ACCMode.labels()],
+                      ["steer",               "STR",                      [""]],
+                      ["brake",               "BRK",                      [""]],
+                      ["msg",                 "MSG",                      [""]],
+                      ["sound",               "SND",                      [""]]]
 
     if (CP.carFingerprint == CAR.MODELS):
       # ALCA PARAMS
@@ -304,10 +304,10 @@ class CarState(object):
    
   def config_ui_buttons(self, pedalPresent):
     if pedalPresent:
-      self.btns_init[1] = ["pedal", "PDL", PCCModes.labels()]
+      self.btns_init[1] = [PCCModes.BUTTON_NAME, PCCModes.BUTTON_ABREVIATION, PCCModes.labels()]
     else:
       # we don't have pedal interceptor
-      self.btns_init[1] = ["acc", "ACC", ACCMode.labels()]
+      self.btns_init[1] = [ACCMode.BUTTON_NAME, ACCMode.BUTTON_ABREVIATION, ACCMode.labels()]
     btn = self.cstm_btns.btns[1]
     btn.btn_name = self.btns_init[1][0]
     btn.btn_label = self.btns_init[1][1]

--- a/selfdrive/car/tesla/carstate.py
+++ b/selfdrive/car/tesla/carstate.py
@@ -3,8 +3,9 @@ from common.kalman.simple_kalman import KF1D
 from selfdrive.can.parser import CANParser
 from selfdrive.config import Conversions as CV
 from selfdrive.car.tesla.ACC_module import ACCMode
+from selfdrive.car.tesla.PCC_module import PCCModes
 from selfdrive.car.tesla.values import CAR, CruiseButtons, DBC
-from selfdrive.car.modules.UIBT_module import UIButtons,UIButton
+from selfdrive.car.modules.UIBT_module import UIButtons, UIButton
 import numpy as np
 from ctypes import create_string_buffer
 from selfdrive.car.modules.UIEV_module import UIEvents
@@ -169,7 +170,7 @@ class CarState(object):
   def __init__(self, CP):
     # labels for buttons
     self.btns_init = [["alca",  "ALC", ["MadMax", "Normal", "Wifey"]],
-                      ["acc",   "ACC", ACCMode.get_labels()],
+                      ["acc",   "ACC", ACCMode.labels()],
                       ["steer", "STR", [""]],
                       ["brake", "BRK", [""]],
                       ["msg",   "MSG", [""]],
@@ -303,10 +304,10 @@ class CarState(object):
    
   def config_ui_buttons(self, pedalPresent):
     if pedalPresent:
-      self.btns_init[1] = ["pedal", "PDL", ["Lng MPC", "Follow"]]
+      self.btns_init[1] = ["pedal", "PDL", PCCModes.labels()]
     else:
       # we don't have pedal interceptor
-      self.btns_init[1] = ["acc", "ACC", ACCMode.get_labels()]
+      self.btns_init[1] = ["acc", "ACC", ACCMode.labels()]
     btn = self.cstm_btns.btns[1]
     btn.btn_name = self.btns_init[1][0]
     btn.btn_label = self.btns_init[1][1]

--- a/selfdrive/car/tesla/carstate.py
+++ b/selfdrive/car/tesla/carstate.py
@@ -234,7 +234,6 @@ class CarState(object):
     self.pedal_interceptor_state = 0
     self.pedal_interceptor_value = 0.
     self.pedal_interceptor_value2 = 0.
-    self.pedal_interceptor_pressed = False
     self.brake_switch_prev = 0
     self.brake_switch_ts = 0
 
@@ -266,7 +265,6 @@ class CarState(object):
 
     #BB variables for pedal CC
     self.pedal_speed_kph = 0.
-    self.pedal_interceptor_present = False
     self.pedal_interceptor_available = False
     self.prev_pedal_interceptor_available = False
 
@@ -371,7 +369,6 @@ class CarState(object):
     self.pedal_interceptor_state = epas_cp.vl["GAS_SENSOR"]['STATE']
     self.pedal_interceptor_value = epas_cp.vl["GAS_SENSOR"]['INTERCEPTOR_GAS']
     self.pedal_interceptor_value2 = epas_cp.vl["GAS_SENSOR"]['INTERCEPTOR_GAS2']
-    self.pedal_interceptor_pressed = self.pedal_interceptor_value > 1.12
 
     can_gear_shifter = cp.vl["DI_torque2"]['DI_gear']
     self.gear = 0 # JCT
@@ -416,15 +413,12 @@ class CarState(object):
     self.imperial_speed_units = cp.vl["DI_state"]['DI_speedUnits'] == 0
     self.regenLight = cp.vl["DI_state"]['DI_regenLight'] == 1
     
-    #BB this is a hack for the interceptor
     self.prev_pedal_interceptor_available = self.pedal_interceptor_available
-    self.pedal_interceptor_present = (
-        self.pedal_interceptor_state == 0
-        and bool(self.pedal_interceptor_value)
-        and bool(self.pedal_interceptor_value2)
-      )
+    pedal_interceptor_present = (self.pedal_interceptor_state in [0, 5]
+                                 and bool(self.pedal_interceptor_value)
+                                 and bool(self.pedal_interceptor_value2))
     # Mark pedal unavailable while traditional cruise is on.
-    self.pedal_interceptor_available = self.pedal_interceptor_present and not bool(self.pcm_acc_status)
+    self.pedal_interceptor_available = pedal_interceptor_present and not bool(self.pcm_acc_status)
     if self.pedal_interceptor_available != self.prev_pedal_interceptor_available:
         self.config_ui_buttons(self.pedal_interceptor_available)
 

--- a/selfdrive/car/tesla/carstate.py
+++ b/selfdrive/car/tesla/carstate.py
@@ -169,7 +169,7 @@ def get_epas_parser(CP):
 class CarState(object):
   def __init__(self, CP):
     # labels for buttons
-    self.btns_init = [["alca",                "ALC",                      ["MadMax", "Normal", "Wifey"]],
+    self.btns_init = [["alca",                "ALC",                      ["MadMax", "Normal", "Calm"]],
                       [ACCMode.BUTTON_NAME,   ACCMode.BUTTON_ABREVIATION, ACCMode.labels()],
                       ["steer",               "STR",                      [""]],
                       ["brake",               "BRK",                      [""]],


### PR DESCRIPTION
*Pedal UI button is now only present if pedal interceptor is present and the cruise stalk is off. Otherwise ACC UI button is shown.
*A new PCC mode called "devel". As the name suggests, it's in development and not particularly safe. Stick to "OP" mode if you want anything remotely safe. (Motivation for the new mode: bypasses the OP planner all together since the planner occasionally fizzles in the absence of radar)
*Code cleanup: Made objects to represent ACC and PCC modes. Button labels are defined only one place in code now.