### PR TITLE
PCC follow mode smoothness work

### DIFF
--- a/selfdrive/car/tesla/ACC_module.py
+++ b/selfdrive/car/tesla/ACC_module.py
@@ -110,6 +110,9 @@ class ACCController(object):
         self.acc_speed_kph = max(CS.v_ego_raw * CV.MS_TO_KPH, self.acc_speed_kph)
         self.user_has_braked = False
         self.has_gone_below_min_speed = False
+      else:
+        # A single pull disables ACC (falling back to just steering).
+        self.enable_adaptive_cruise = False
     # Handle pressing the cancel button.
     elif CS.cruise_buttons == CruiseButtons.CANCEL:
       self.enable_adaptive_cruise = False

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -255,7 +255,7 @@ class PCCController(object):
       CS.cstm_btns.set_button_status("pedal", 1 if self.pedal_interceptor_state > 0 else 0)
       if self.pedal_interceptor_state > 0:
         if self.pedal_interceptor_state == 5:
-          CS.UE.custom_alert_message(3, "Pedal Interceptor Disabled.", 150, 4)
+          CS.UE.custom_alert_message(3, "Pedal Interceptor Off", 150, 4)
         else:
           CS.UE.custom_alert_message(3, "Pedal Interceptor Error (%s)" % self.pedal_interceptor_state, 150, 4)
         # send reset command
@@ -263,6 +263,8 @@ class PCCController(object):
         self.pedal_idx = (self.pedal_idx + 1) % 16
         can_sends.append(teslacan.create_pedal_command_msg(0, 0, idx))
         sendcan.send(can_list_to_can_capnp(can_sends, msgtype='sendcan').to_bytes())
+      elif self.pedal_interceptor_state == 0:
+        CS.UE.custom_alert_message(2, "Pedal Interceptor On", 150)
     # disable on brake
     if CS.brake_pressed and self.enable_pedal_cruise:
       self.enable_pedal_cruise = False

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -54,11 +54,11 @@ AWARENESS_DECEL = -0.2     # car smoothly decel at .2m/s^2 when user is distract
 # Make sure these accelerations are smaller than mpc limits.
 _A_CRUISE_MIN = OrderedDict([
   # (speed in m/s, allowed deceleration)
-  (0.0, 1.0),
-  (5.0, 1.0),
-  (10., 1.0),
-  (20., 0.9),
-  (40., 0.8)])
+  (0.0, 1.5),
+  (5.0, 1.4),
+  (10., 1.3),
+  (20., 0.95),
+  (40., 0.9)])
 
 # Map of speed to max allowed acceleration.
 # Need higher accel at very low speed for stop and go.
@@ -68,8 +68,8 @@ _A_CRUISE_MAX = OrderedDict([
   (0.0, 0.5),
   (5.0, 0.4),
   (10., 0.3),
-  (20., 0.3),
-  (40., 0.3)])
+  (20., 0.25),
+  (40., 0.22)])
   
 # Lookup table for turns
 _A_TOTAL_MAX = OrderedDict([

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -255,7 +255,7 @@ class PCCController(object):
       CS.cstm_btns.set_button_status("pedal", 1 if self.pedal_interceptor_state > 0 else 0)
       if self.pedal_interceptor_state > 0:
         if self.pedal_interceptor_state == 5:
-          CS.UE.custom_alert_message(3, "Pedal Interceptor Disabled (%s)" % self.pedal_interceptor_state, 150, 4)
+          CS.UE.custom_alert_message(3, "Pedal Interceptor Disabled.", 150, 4)
         else:
           CS.UE.custom_alert_message(3, "Pedal Interceptor Error (%s)" % self.pedal_interceptor_state, 150, 4)
         # send reset command

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -371,7 +371,7 @@ class PCCController(object):
     # how much accel and break we have to do
     ####################################################################
     if PCCModes.is_selected(FollowMode(), CS.cstm_btns):
-      self.v_pid = self.calc_follow_speed(CS)
+      self.v_pid = self.calc_follow_speed_ms(CS)
       # cruise speed can't be negative even is user is distracted
       self.v_pid = max(self.v_pid, 0.)
 
@@ -379,7 +379,7 @@ class PCCController(object):
 
       if self.enable_pedal_cruise:
         # TODO: make a separate lookup for jerk tuning
-        jerk_min, jerk_max = _jerk_limits(v_ego, lead)
+        jerk_min, jerk_max = _jerk_limits(CS.v_ego, self.lead_1)
         self.v_cruise, self.a_cruise = speed_smoother(self.v_acc_start, self.a_acc_start,
                                                       self.v_pid,
                                                       accel_max, brake_max,
@@ -536,7 +536,7 @@ class PCCController(object):
     return self.prev_tesla_pedal, enable_pedal, idx
 
   # function to calculate the cruise speed based on a safe follow distance
-  def calc_follow_speed(self, CS):
+  def calc_follow_speed_ms(self, CS):
      # Make sure we were able to populate lead_1.
     if self.lead_1 is None:
       return None, None, None

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -1,5 +1,4 @@
 from selfdrive.car.tesla import teslacan
-#from selfdrive.controls.lib.pid import PIController
 from selfdrive.car.tesla.longcontrol_tesla import LongControl, LongCtrlState, STARTING_TARGET_SPEED
 from selfdrive.car.tesla import teslacan
 from common.numpy_fast import clip, interp
@@ -55,11 +54,11 @@ AWARENESS_DECEL = -0.2     # car smoothly decel at .2m/s^2 when user is distract
 # Make sure these accelerations are smaller than mpc limits.
 _A_CRUISE_MIN = OrderedDict([
   # (speed in m/s, allowed deceleration)
-  (0.0, -6.0),
-  (5.0, -5.0),
-  (10., -4.0),
-  (20., -3.0),
-  (40., -2.0)])
+  (0.0, 1.0),
+  (5.0, 1.0),
+  (10., 1.0),
+  (20., 0.9),
+  (40., 0.8)])
 
 # Map of speed to max allowed acceleration.
 # Need higher accel at very low speed for stop and go.
@@ -67,9 +66,9 @@ _A_CRUISE_MIN = OrderedDict([
 _A_CRUISE_MAX = OrderedDict([
   # (speed in m/s, allowed acceleration)
   (0.0, 0.9),
-  (5.0, 0.6),
-  (10., 0.5),
-  (20., 0.4),
+  (5.0, 0.7),
+  (10., 0.6),
+  (20., 0.5),
   (40., 0.3)])
   
 # Lookup table for turns

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -716,13 +716,13 @@ def _jerk_limits(v_ego, lead):
   if lead and lead.dRel:
     safe_dist_m = _safe_distance_m(v_ego)
     jerk_min_map = OrderedDict([
-      # (distance in m, jerk)
+      # (distance in m, decel jerk)
       (0.5 * safe_dist_m, -0.3),
       (1.0 * safe_dist_m, -0.15)])
     jerk_min = _interp_map(lead.dRel, jerk_min_map)
     jerk_max_map = OrderedDict([
-      # (distance in m, jerk)
-      (0.5 * safe_dist_m, 0.06),
+      # (distance in m, accel jerk)
+      (1.0 * safe_dist_m, 0.06),
       (2.0 * safe_dist_m, 0.12)])
     jerk_max = _interp_map(lead.dRel, jerk_max_map)
     return jerk_min, jerk_max

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -383,7 +383,7 @@ class PCCController(object):
       if self.enable_pedal_cruise:
         accel_min, accel_max = calc_cruise_accel_limits(CS)
         accel_min *= accel_modifier
-        accel max *= accel_modifier
+        accel_max *= accel_modifier
         # TODO: make a separate lookup for jerk tuning
         jerk_min = min(-0.1, accel_min)
         jerk_max = max(0.1, accel_max)
@@ -622,7 +622,7 @@ class PCCController(object):
 def _visual_radar_adjusted_dist_m(m):
   # visual radar sucks at short distances. It rarely shows readings below 7m.
   # So rescale distances with 7m -> 0m. Maxes out at 100km, if that matters.
-  return = interp(m, [0, 7, 300, 100000], [0, 0, 300, 10000])
+  return interp(m, [0, 7, 300, 100000], [0, 0, 300, 10000])
 
 def _safe_distance_m(v_ego_ms):
   return max(FOLLOW_TIME_S * v_ego_ms, MIN_SAFE_DIST_M)
@@ -672,7 +672,7 @@ def _weighted_distance_ratio(lead, v_ego, max_decel_ratio, max_accel_ratio):
     (optimal_dist_m*1, 1),
     (optimal_dist_m*2, max_accel_ratio),
     (optimal_dist_m*1000, max_accel_ratio)])
-    dist = _visual_radar_adjusted_dist_m(lead.dRel)
+  dist = _visual_radar_adjusted_dist_m(lead.dRel)
   return  interp(dist, d_weights.keys(), d_weights.values())
   
 def _weighted_velocity_ratio(lead, v_ego, max_decel_ratio, max_accel_ratio):

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -65,11 +65,11 @@ _A_CRUISE_MIN = OrderedDict([
 # Need higher accel at very low speed for stop and go.
 # make sure these accelerations are smaller than mpc limits.
 _A_CRUISE_MAX = OrderedDict([
-  (0.0, 1.0),
-  (5.0, 0.8),
-  (10., 0.7),
-  (20., 0.6),
-  (40., 0.4)])
+  (0.0, 0.8),
+  (5.0, 0.6),
+  (10., 0.5),
+  (20., 0.4),
+  (40., 0.3)])
   
 # Lookup table for turns
 _A_TOTAL_MAX = OrderedDict([

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -94,7 +94,7 @@ class FollowMode(Mode):
   label = 'FOLLOW'
 
 class ExperimentalMode(Mode):
-  label = 'EXPRMNT'
+  label = 'DEVEL'
   
 class PCCModes(object):
   _all_modes = [OffMode(), OpMode(), FollowMode(), ExperimentalMode()]

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -559,32 +559,12 @@ class PCCController(object):
     # Current speed in kph
     actual_speed_kph = CS.v_ego * CV.MS_TO_KPH
     # speed and brake to issue
-    #new_speed_kph = max(actual_speed_kph, self.last_speed_kph)
-    #new_brake = 1.
-    # debug msg
-    msg = None
-    msg2 = " *** UNKNOWN *** "
-
-    #if self.last_md_ts == self.md_ts or self.last_l100_ts == self.l100_ts:
-    #  # no radar update, so just keep doing what we're doing
-    #  new_speed_kph = self.last_speed_kph
-    #  new_brake = self.last_brake
-    #  msg2 = "No change - No Data"
-    #  if DEBUG:
-    #    if msg:
-    #      print msg
-    #    CS.UE.custom_alert_message(2, "%s [%s]" % (msg2, int(new_speed_kph*CV.KPH_TO_MPH)), 6, 0)
-    #  else:
-    #    print msg2
-    #  return new_speed_kph * CV.KPH_TO_MS, new_brake
     new_speed_kph = self.last_speed_kph
     new_brake = self.last_brake
     ###   Logic to determine best cruise speed ###
     if self.enable_pedal_cruise:
       # If no lead is present, accel up to max speed
       if lead_dist_m == 0:
-        msg =  "Set to max"
-        msg2 = "LD = 0, V = max"
         new_speed_kph = self.pedal_speed_kph
         new_brake = 2.
       elif lead_dist_m > 0:
@@ -600,13 +580,13 @@ class PCCController(object):
         elif lead_dist_m < safe_dist_m * 1.5:
           new_speed_kph = actual_speed_kph
           if abs(rel_speed_kph) > 3:
-            new_speed_kph = actual_speed_kph + clip(rel_speed_kph / 2, -3, 3)
+            new_speed_kph = actual_speed_kph + clip(rel_speed_kph / 3, -3, 3)
             print 'PCC ='
           else:
             print 'PCC =='
         # if too far and not gaining, increase speed
-        elif lead_dist_m > safe_dist_m * 1.5 and rel_speed_kph > -1:
-          new_speed_kph = actual_speed_kph + clip(rel_speed_kph / 2, 2, 5)
+        elif lead_dist_m > safe_dist_m * 1.5 and rel_speed_kph > 0:
+          new_speed_kph = actual_speed_kph + clip(rel_speed_kph / 3, 0, 4)
           print 'PCC +'
         # Visual radar sucks at great distances, but consider action if
         # relative speed is significant.
@@ -623,12 +603,6 @@ class PCCController(object):
       new_speed_kph = clip(new_speed_kph, 0, self.pedal_speed_kph)
       self.last_speed_kph = new_speed_kph
       self.last_brake = new_brake
-      if DEBUG:
-        if msg:
-          print msg
-        CS.UE.custom_alert_message(2, "%s [%s]" % (msg2, int(new_speed_kph*CV.KPH_TO_MPH)), 6, 0)
-      #else:
-        #print msg2
 
     return new_speed_kph * CV.KPH_TO_MS , new_brake
 

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -65,7 +65,7 @@ _A_CRUISE_MIN = OrderedDict([
 # Need higher accel at very low speed for stop and go.
 # make sure these accelerations are smaller than mpc limits.
 _A_CRUISE_MAX = OrderedDict([
-  (0.0, 0.8),
+  (0.0, 0.9),
   (5.0, 0.6),
   (10., 0.5),
   (20., 0.4),
@@ -561,7 +561,7 @@ class PCCController(object):
     # speed and brake to issue
     new_speed_kph = self.last_speed_kph
     new_brake = self.last_brake
-    accel_multiplier  # < 1 to signal when less acceleration is warranted
+    accel_multiplier = 1 # < 1 to signal when less acceleration is warranted
     ###   Logic to determine best cruise speed ###
     if self.enable_pedal_cruise:
       # If no lead is present, accel up to max speed

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -254,7 +254,10 @@ class PCCController(object):
       self.pedal_interceptor_state = CS.pedal_interceptor_state
       CS.cstm_btns.set_button_status("pedal", 1 if self.pedal_interceptor_state > 0 else 0)
       if self.pedal_interceptor_state > 0:
-        CS.UE.custom_alert_message(3, "Pedal Interceptor Error (%s)" % self.pedal_interceptor_state, 150, 4)
+        if self.pedal_interceptor_state == 5:
+          CS.UE.custom_alert_message(3, "Pedal Interceptor Disabled (%s)" % self.pedal_interceptor_state, 150, 4)
+        else:
+          CS.UE.custom_alert_message(3, "Pedal Interceptor Error (%s)" % self.pedal_interceptor_state, 150, 4)
         # send reset command
         idx = self.pedal_idx
         self.pedal_idx = (self.pedal_idx + 1) % 16

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -65,8 +65,8 @@ _A_CRUISE_MIN = OrderedDict([
 # make sure these accelerations are smaller than mpc limits.
 _A_CRUISE_MAX = OrderedDict([
   # (speed in m/s, allowed acceleration)
-  (0.0, 0.4),
-  (5.0, 0.3),
+  (0.0, 0.5),
+  (5.0, 0.4),
   (10., 0.3),
   (20., 0.3),
   (40., 0.3)])
@@ -705,26 +705,26 @@ def _decel_limit_multiplier(v_ego, lead):
     safe_dist_m = _safe_distance_m(v_ego)
     decel_multipliers = OrderedDict([
        # (distance in m, acceleration fraction)
-       (0.4 * safe_dist_m, 1.0),
-       (1.4 * safe_dist_m, 0.2),
-       (1.9 * safe_dist_m, 0.1)])
+       (0.5 * safe_dist_m, 1.0),
+       (1.0 * safe_dist_m, 0.5), # new
+       (2.0 * safe_dist_m, 0.1)])
     return _interp_map(lead.dRel, decel_multipliers)
   else:
-    return 1
+    return 1.0
     
 def _jerk_limits(v_ego, lead):
   if lead and lead.dRel:
     safe_dist_m = _safe_distance_m(v_ego)
-    jerk_min_map = OrderedDict([
+    decel_jerk_map = OrderedDict([
       # (distance in m, decel jerk)
-      (0.5 * safe_dist_m, -0.3),
-      (1.0 * safe_dist_m, -0.15)])
-    jerk_min = _interp_map(lead.dRel, jerk_min_map)
-    jerk_max_map = OrderedDict([
+      (0.5 * safe_dist_m, -0.5),
+      (1.0 * safe_dist_m, -0.18)])
+    decel_jerk = _interp_map(lead.dRel, decel_jerk_map)
+    accel_jerk_map = OrderedDict([
       # (distance in m, accel jerk)
-      (1.0 * safe_dist_m, 0.06),
-      (2.0 * safe_dist_m, 0.12)])
-    jerk_max = _interp_map(lead.dRel, jerk_max_map)
-    return jerk_min, jerk_max
+      (1.0 * safe_dist_m, 0.04),
+      (2.0 * safe_dist_m, 0.07)])
+    accel_jerk = _interp_map(lead.dRel, accel_jerk_map)
+    return decel_jerk, accel_jerk
   else:
-    return -0.15, 0.10
+    return -0.15, 0.8

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -290,6 +290,9 @@ class PCCController(object):
         self.LoC.reset(CS.v_ego)
         # Increase PCC speed to match current, if applicable.
         self.pedal_speed_kph = max(CS.v_ego * CV.MS_TO_KPH, self.pedal_speed_kph)
+      else:
+        # A single pull disables PCC (falling back to just steering).
+        self.enable_pedal_cruise = False
     # Handle pressing the cancel button.
     elif CS.cruise_buttons == CruiseButtons.CANCEL:
       self.enable_pedal_cruise = False
@@ -475,8 +478,8 @@ class PCCController(object):
           weighted_d_ratio = _weighted_distance_ratio(self.lead_1, CS.v_ego, MAX_DECEL_RATIO, MAX_ACCEL_RATIO)
           weighted_v_ratio = _weighted_velocity_ratio(self.lead_1, CS.v_ego, MAX_DECEL_RATIO, MAX_ACCEL_RATIO)
           # Don't bother decelerating if the lead is already pulling away
-          if weighted_d_ratio < 1 and weighted_v_ratio > 1:
-            gas_brake_ratio = 1
+          if weighted_d_ratio < 1 and weighted_v_ratio > 1.01:
+            gas_brake_ratio = max(1, self.last_output_gb + 1)
           else:
             gas_brake_ratio = weighted_d_ratio * weighted_v_ratio
           # rescale around 0 rather than 1.

--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -254,17 +254,14 @@ class PCCController(object):
       self.pedal_interceptor_state = CS.pedal_interceptor_state
       CS.cstm_btns.set_button_status("pedal", 1 if self.pedal_interceptor_state > 0 else 0)
       if self.pedal_interceptor_state > 0:
-        if self.pedal_interceptor_state == 5:
-          CS.UE.custom_alert_message(3, "Pedal Interceptor Off", 150, 4)
-        else:
-          CS.UE.custom_alert_message(3, "Pedal Interceptor Error (%s)" % self.pedal_interceptor_state, 150, 4)
         # send reset command
         idx = self.pedal_idx
         self.pedal_idx = (self.pedal_idx + 1) % 16
         can_sends.append(teslacan.create_pedal_command_msg(0, 0, idx))
         sendcan.send(can_list_to_can_capnp(can_sends, msgtype='sendcan').to_bytes())
-      elif self.pedal_interceptor_state == 0:
-        CS.UE.custom_alert_message(2, "Pedal Interceptor On", 150)
+        CS.UE.custom_alert_message(3, "Pedal Interceptor Off (state %s)" % self.pedal_interceptor_state, 150, 3)
+      else:
+        CS.UE.custom_alert_message(3, "Pedal Interceptor On", 150, 3)
     # disable on brake
     if CS.brake_pressed and self.enable_pedal_cruise:
       self.enable_pedal_cruise = False

--- a/selfdrive/car/tesla/carstate.py
+++ b/selfdrive/car/tesla/carstate.py
@@ -234,7 +234,7 @@ class CarState(object):
     self.pedal_interceptor_state = 0
     self.pedal_interceptor_value = 0.
     self.pedal_interceptor_value2 = 0.
-    self.pedal_interceptor_counter = 0
+    self.pedal_interceptor_missed_counter = 0
     self.brake_switch_prev = 0
     self.brake_switch_ts = 0
 
@@ -266,12 +266,9 @@ class CarState(object):
 
     #BB variables for pedal CC
     self.pedal_speed_kph = 0.
-    # Pedal interceptor hardware has been seen at least once
-    self.pedal_interceptor_present = False
     # Pedal mode is ready, i.e. hardware is present and normal cruise is off.
     self.pedal_interceptor_available = False
     self.prev_pedal_interceptor_available = False
-    self.prev_pedal_interceptor_present = False
 
     #BB UIEvents
     self.UE = UIEvents(self)
@@ -420,17 +417,15 @@ class CarState(object):
     
     self.prev_pedal_interceptor_available = self.pedal_interceptor_available
     pedal_has_value = bool(self.pedal_interceptor_value) or bool(self.pedal_interceptor_value2)
-    pedal_interceptor_present = (self.pedal_interceptor_state in [0, 5] and pedal_has_value)
+    pedal_interceptor_present = self.pedal_interceptor_state in [0, 5] and pedal_has_value
     # Add loggic if we just miss some CAN messages so we don't immediately disable pedal
     if pedal_interceptor_present:
-      self.pedal_interceptor_counter = 0
-    if self.prev_pedal_interceptor_present and not pedal_interceptor_present:
-      self.pedal_interceptor_counter += 1
-      if self.pedal_interceptor_counter < 10:
-        pedal_interceptor_present = self.prev_pedal_interceptor_present
-    self.prev_pedal_interceptor_present = pedal_interceptor_present
+      self.pedal_interceptor_missed_counter = 0
+    else:
+      self.pedal_interceptor_missed_counter += 1
+    pedal_interceptor_present = self.pedal_interceptor_missed_counter < 10
     # Mark pedal unavailable while traditional cruise is on.
-    self.pedal_interceptor_available = self.pedal_interceptor_present and not bool(self.pcm_acc_status)
+    self.pedal_interceptor_available = pedal_interceptor_present and not bool(self.pcm_acc_status)
     if self.pedal_interceptor_available != self.prev_pedal_interceptor_available:
         self.config_ui_buttons(self.pedal_interceptor_available)
 

--- a/selfdrive/car/tesla/carstate.py
+++ b/selfdrive/car/tesla/carstate.py
@@ -265,6 +265,9 @@ class CarState(object):
 
     #BB variables for pedal CC
     self.pedal_speed_kph = 0.
+    # Pedal interceptor hardware has been seen at least once
+    self.pedal_interceptor_present = False
+    # Pedal mode is ready, i.e. hardware is present and normal cruise is off.
     self.pedal_interceptor_available = False
     self.prev_pedal_interceptor_available = False
 
@@ -414,11 +417,12 @@ class CarState(object):
     self.regenLight = cp.vl["DI_state"]['DI_regenLight'] == 1
     
     self.prev_pedal_interceptor_available = self.pedal_interceptor_available
-    pedal_interceptor_present = (self.pedal_interceptor_state in [0, 5]
-                                 and bool(self.pedal_interceptor_value)
-                                 and bool(self.pedal_interceptor_value2))
+    if not self.pedal_interceptor_present:
+      # 'present' means the hardware has been seen at least once this session.
+      pedal_has_value = bool(self.pedal_interceptor_value) or bool(self.pedal_interceptor_value2)
+      self.pedal_interceptor_present = (self.pedal_interceptor_state in [0, 5] and pedal_has_value)
     # Mark pedal unavailable while traditional cruise is on.
-    self.pedal_interceptor_available = pedal_interceptor_present and not bool(self.pcm_acc_status)
+    self.pedal_interceptor_available = self.pedal_interceptor_present and not bool(self.pcm_acc_status)
     if self.pedal_interceptor_available != self.prev_pedal_interceptor_available:
         self.config_ui_buttons(self.pedal_interceptor_available)
 

--- a/selfdrive/car/tesla/carstate.py
+++ b/selfdrive/car/tesla/carstate.py
@@ -419,9 +419,8 @@ class CarState(object):
     self.regenLight = cp.vl["DI_state"]['DI_regenLight'] == 1
     
     self.prev_pedal_interceptor_available = self.pedal_interceptor_available
-    pedal_interceptor_present = (self.pedal_interceptor_state in [0, 5]
-                                 and bool(self.pedal_interceptor_value)
-                                 and bool(self.pedal_interceptor_value2))
+    pedal_has_value = bool(self.pedal_interceptor_value) or bool(self.pedal_interceptor_value2)
+    pedal_interceptor_present = (self.pedal_interceptor_state in [0, 5] and pedal_has_value)
     # Add loggic if we just miss some CAN messages so we don't immediately disable pedal
     if pedal_interceptor_present:
       self.pedal_interceptor_counter = 0

--- a/selfdrive/car/tesla/carstate.py
+++ b/selfdrive/car/tesla/carstate.py
@@ -234,7 +234,6 @@ class CarState(object):
     self.pedal_interceptor_state = 0
     self.pedal_interceptor_value = 0.
     self.pedal_interceptor_value2 = 0.
-    self.pedal_interceptor_pressed = False
     self.brake_switch_prev = 0
     self.brake_switch_ts = 0
 
@@ -266,7 +265,6 @@ class CarState(object):
 
     #BB variables for pedal CC
     self.pedal_speed_kph = 0.
-    self.pedal_interceptor_present = False
     self.pedal_interceptor_available = False
     self.prev_pedal_interceptor_available = False
 
@@ -371,7 +369,6 @@ class CarState(object):
     self.pedal_interceptor_state = epas_cp.vl["GAS_SENSOR"]['STATE']
     self.pedal_interceptor_value = epas_cp.vl["GAS_SENSOR"]['INTERCEPTOR_GAS']
     self.pedal_interceptor_value2 = epas_cp.vl["GAS_SENSOR"]['INTERCEPTOR_GAS2']
-    self.pedal_interceptor_pressed = self.pedal_interceptor_value > 1.12
 
     can_gear_shifter = cp.vl["DI_torque2"]['DI_gear']
     self.gear = 0 # JCT
@@ -416,15 +413,12 @@ class CarState(object):
     self.imperial_speed_units = cp.vl["DI_state"]['DI_speedUnits'] == 0
     self.regenLight = cp.vl["DI_state"]['DI_regenLight'] == 1
     
-    #BB this is a hack for the interceptor
     self.prev_pedal_interceptor_available = self.pedal_interceptor_available
-    self.pedal_interceptor_present = (
-        self.pedal_interceptor_state == 0
-        and bool(self.pedal_interceptor_value)
-        and bool(self.pedal_interceptor_value2)
-      )
+    pedal_interceptor_present = (self.pedal_interceptor_state in [0, 5]
+                                 and bool(self.pedal_interceptor_value)
+                                 and bool(self.pedal_interceptor_value2))
     # Mark pedal unavailable while traditional cruise is on.
-    self.pedal_interceptor_available = self.pedal_interceptor_present and not bool(self.pcm_acc_status)
+    self.pedal_interceptor_available = pedal_interceptor_present and not bool(self.pcm_acc_status)
     if self.pedal_interceptor_available != self.prev_pedal_interceptor_available:
         self.config_ui_buttons(self.pedal_interceptor_available)
 


### PR DESCRIPTION
These changes focus on making PCC follow mode less jerky. The max acceleration and jerk is now tied to distance from the lead car. When too far, braking amount&jerk is suppressed. When too close, acceleration amount&jerk is suppressed. This results in less frantic behavior.

More importantly, it fixes my previous commits which didn't brake enough at close distances.