### PR TITLE
Add angular acceleration and rate to Tesla's lateral control

### DIFF
--- a/selfdrive/controls/lib/latcontrol.py
+++ b/selfdrive/controls/lib/latcontrol.py
@@ -37,6 +37,21 @@ class LatControl(object):
                             k_f=CP.steerKf, pos_limit=1.0)
     self.last_cloudlog_t = 0.0
     self.setup_mpc(CP.steerRateCost)
+    self.smooth_factor = 2.0 * CP.steerActuatorDelay / _DT      # Multiplier for inductive component (feed forward)
+    self.projection_factor = 5.0 * _DT                       #  Mutiplier for reactive component (PI)
+    self.accel_limit = 5.0                                 # Desired acceleration limit to prevent "whip steer" (resistive component)
+    self.ff_angle_factor = 0.5         # Kf multiplier for angle-based feed forward
+    self.ff_rate_factor = 5.0         # Kf multiplier for rate-based feed forward
+    self.ratioDelayExp = 2.0           # Exponential coefficient for variable steering rate (delay)
+    self.ratioDelayScale = 0.0          # Multiplier for variable steering rate (delay)
+    self.prev_angle_rate = 0
+    self.feed_forward = 0.0
+    self.angle_rate_desired = 0.0
+
+    # variables for dashboarding
+    self.frames = 0
+    self.curvature_factor = 0.0
+    self.slip_factor = 0.0
 
   def setup_mpc(self, steer_rate_cost):
     self.libmpc = libmpc_py.libmpc
@@ -54,35 +69,46 @@ class LatControl(object):
     self.last_mpc_ts = 0.0
     self.angle_steers_des = 0.0
     self.angle_steers_des_mpc = 0.0
-    self.starting_angle_steers = 0.0
-    self.avg_angle_rate = 0.0
-    self.angle_rate_count = 0.0
+    self.angle_steers_des_prev = 0.0
+    self.angle_steers_des_time = 0.0
 
   def reset(self):
     self.pid.reset()
 
   def update(self, active, v_ego, angle_steers, angle_rate, steer_override, d_poly, angle_offset, CP, VM, PL):
+    cur_time = sec_since_boot()    
     self.mpc_updated = False
     # TODO: this creates issues in replay when rewinding time: mpc won't run
     if self.last_mpc_ts < PL.last_md_ts:
       self.last_mpc_ts = PL.last_md_ts
-      self.starting_angle_steers = angle_steers
-      self.avg_angle_rate = 0.0
-      self.angle_rate_count = 0.0
+      self.angle_steers_des_prev = self.angle_steers_des_mpc
 
-      curvature_factor = VM.curvature_factor(v_ego)
+      self.curvature_factor = VM.curvature_factor(v_ego)
 
-      l_poly = libmpc_py.ffi.new("double[4]", list(PL.PP.l_poly))
-      r_poly = libmpc_py.ffi.new("double[4]", list(PL.PP.r_poly))
-      p_poly = libmpc_py.ffi.new("double[4]", list(PL.PP.p_poly))
+      # This is currently disabled, but it is used to compensate for variable steering rate
+      ratioDelayFactor = 1. + self.ratioDelayScale * abs(angle_steers / 100.) ** self.ratioDelayExp
 
-      # account for actuation delay
-      self.cur_state = calc_states_after_delay(self.cur_state, v_ego, angle_steers, curvature_factor, CP.steerRatio, CP.steerActuatorDelay)
+      # Determine a proper delay time that includes the model's processing time, which is variable
+      plan_age = _DT_MPC + cur_time - float(PL.last_md_ts / 1000000000.0) 
+      total_delay = ratioDelayFactor * CP.steerActuatorDelay + plan_age
+
+      # Use steering rate from the last 2 samples to estimate acceleration for a more realistic future steering rate
+      accelerated_angle_rate = 2.0 * angle_rate - self.prev_angle_rate    
+
+      # Project the future steering angle for the actuator delay only (not model delay)
+      projected_angle_steers = ratioDelayFactor * CP.steerActuatorDelay * accelerated_angle_rate + angle_steers
+
+      self.l_poly = libmpc_py.ffi.new("double[4]", list(PL.PP.l_poly))
+      self.r_poly = libmpc_py.ffi.new("double[4]", list(PL.PP.r_poly))
+      self.p_poly = libmpc_py.ffi.new("double[4]", list(PL.PP.p_poly))
+
+      # account for actuation delay and the age of the plan
+      self.cur_state = calc_states_after_delay(self.cur_state, v_ego, projected_angle_steers, self.curvature_factor, CP.steerRatio, total_delay)
 
       v_ego_mpc = max(v_ego, 5.0)  # avoid mpc roughness due to low speed
       self.libmpc.run_mpc(self.cur_state, self.mpc_solution,
-                          l_poly, r_poly, p_poly,
-                          PL.PP.l_prob, PL.PP.r_prob, PL.PP.p_prob, curvature_factor, v_ego_mpc, PL.PP.lane_width)
+                          self.l_poly, self.r_poly, self.p_poly,
+                          PL.PP.l_prob, PL.PP.r_prob, PL.PP.p_prob, self.curvature_factor, v_ego_mpc, PL.PP.lane_width)
 
       # reset to current steer angle if not active or overriding
       if active:
@@ -93,6 +119,12 @@ class LatControl(object):
       self.cur_state[0].delta = delta_desired
 
       self.angle_steers_des_mpc = float(math.degrees(delta_desired * CP.steerRatio) + angle_offset)
+      
+      # Use the model's solve time instead of cur_time
+      self.angle_steers_des_time = float(PL.last_md_ts / 1000000000.0)
+      
+      # Use last 2 desired angles to determine the model's desired steer rate
+      self.angle_rate_desired = (self.angle_steers_des_mpc - self.angle_steers_des_prev) / _DT_MPC
       self.mpc_updated = True
 
       #  Check for infeasable MPC solution
@@ -108,30 +140,48 @@ class LatControl(object):
 
     if v_ego < 0.3 or not active:
       output_steer = 0.0
+      self.feed_forward = 0.0
       self.pid.reset()
     else:
-      # Calculate average steering rate since last MPC update
-      self.avg_angle_rate = (self.avg_angle_rate * self.angle_rate_count + angle_rate) / (self.angle_rate_count + 1.) 
-      self.angle_rate_count += 1.0
+      # Interpolate desired angle between MPC updates
+      self.angle_steers_des = self.angle_steers_des_prev + self.angle_rate_desired * (cur_time - self.angle_steers_des_time)
 
-      if abs(angle_rate) <= 1. or abs(angle_steers - self.angle_steers_des_mpc) <= 0.2:
-        # For small steering error, use instantaneous angle for torque calculation
-        future_angle_steers = angle_steers
-      else:
-        # Otherwise, use average steering rate since last MPC update to project future steering error
-        future_angle_steers = (self.avg_angle_rate * _DT_MPC) + self.starting_angle_steers
+      # Determine the target steer rate for desired angle, but prevent the acceleration limit from being exceeded
+      # Restricting the steer rate creates the resistive component needed for resonance
+      restricted_steer_rate = np.clip(self.angle_steers_des - float(angle_steers) , float(angle_rate) - self.accel_limit, float(angle_rate) + self.accel_limit)
+
+      # Determine projected desired angle that is within the acceleration limit (prevent the steering wheel from jerking)
+      projected_angle_steers_des = self.angle_steers_des + self.projection_factor * restricted_steer_rate
+
+      # Determine project angle steers using current steer rate
+      projected_angle_steers = float(angle_steers) + self.projection_factor * float(angle_rate)
 
       steers_max = get_steer_max(CP, v_ego)
       self.pid.pos_limit = steers_max
       self.pid.neg_limit = -steers_max
+
       if CP.steerControlType == car.CarParams.SteerControlType.torque:
-        steer_feedforward = apply_deadzone(self.angle_steers_des_mpc - float(angle_offset), 0.5) 
-        steer_feedforward *= v_ego**2  # proportional to realigning tire momentum (~ lateral accel)
+        # Decide which feed forward mode should be used (angle or rate).  Use more dominant mode, and only if conditions are met
+        # Spread feed forward out over a period of time to make it more inductive (for resonance)
+        if abs(self.ff_rate_factor * float(restricted_steer_rate)) > abs(self.ff_angle_factor * float(self.angle_steers_des) - float(angle_offset)) - 0.5 \
+            and (abs(float(restricted_steer_rate)) > abs(angle_rate) or (float(restricted_steer_rate) < 0) != (angle_rate < 0)) \
+            and (float(restricted_steer_rate) < 0) == (float(self.angle_steers_des) - float(angle_offset) - 0.5 < 0):
+          ff_type = "r"
+          self.feed_forward = (((self.smooth_factor - 1.) * self.feed_forward) + self.ff_rate_factor * v_ego**2 * float(restricted_steer_rate)) / self.smooth_factor  
+        elif abs(self.angle_steers_des - float(angle_offset)) > 0.5:
+          ff_type = "a"
+          self.feed_forward = (((self.smooth_factor - 1.) * self.feed_forward) + self.ff_angle_factor * v_ego**2 * float(apply_deadzone(float(self.angle_steers_des) - float(angle_offset), 0.5))) / self.smooth_factor  
+        else:
+          ff_type = "r"
+          self.feed_forward = (((self.smooth_factor - 1.) * self.feed_forward) + 0.0) / self.smooth_factor  
       else:
-        steer_feedforward = self.angle_steers_des_mpc   # feedforward desired angle
+        self.feed_forward = float(self.angle_steers_des)
       deadzone = 0.0
 
-      output_steer = self.pid.update(self.angle_steers_des_mpc, future_angle_steers, check_saturation=(v_ego > 10), override=steer_override,
-                                     feedforward=steer_feedforward, speed=v_ego, deadzone=deadzone)
+      # Use projected desired and actual angles instead of "current" values, in order to make PI more reactive (for resonance)
+      output_steer = self.pid.update(projected_angle_steers_des, projected_angle_steers, check_saturation=(v_ego > 10), override=steer_override,
+                                     feedforward=self.feed_forward, speed=v_ego, deadzone=deadzone)
+
     self.sat_flag = self.pid.saturated
-    return output_steer, float(self.angle_steers_des_mpc)
+    self.prev_angle_rate = angle_rate
+    return output_steer, float(self.angle_steers_des)


### PR DESCRIPTION
The enhancements below should result in significant improvements in Tesla's lateral control.

* Future steering state is more accurately determined using current steering angle, current angular rate and observed angular acceleration
* Current desired steering angle is more accurately interpolated between MPC updates
* Steering error is more accurately determined using **_current_** angular rate and **_desired_** angular rate
* Steering plan is adjusted for smoothness by applying an angular acceleration limit
* Smoother steering execution results in less _**noise**_ in the vision pipeline (feedback)

Since this hasn't been tested using any steer-by-angle platforms, it may be necessary to alter 1 or more coefficients.  If the steering is not completely smooth, try reducing the multiplier for projection_factor from 5.0 to 2.0 (or even 0.0).