### PR TITLE
Crashfix for crash introduced in PR #50

### DIFF
--- a/selfdrive/car/tesla/readconfig.py
+++ b/selfdrive/car/tesla/readconfig.py
@@ -5,7 +5,7 @@ config_file_r = 'r'
 config_file_w = 'wb'
 
 ### Do NOT modify here, modify in /data/bb_openpilot.cfg and reboot
-def read_config_file(CS, config_path):
+def read_config_file(CS, config_path = default_config_file_path):
     file_changed = False
     configr = ConfigParser.ConfigParser()
 

--- a/selfdrive/car/tesla/test_readconfig.py
+++ b/selfdrive/car/tesla/test_readconfig.py
@@ -34,7 +34,8 @@ class MyTest(unittest.TestCase):
         os.remove(config_file_path)
 
     #def test_readconfig_no_arguments(self):
-    #    cs = readconfig.CarSettings()
+    #    cs1 = readconfig.CarSettings()
+    #    cs2 = read_config_file()
 
     def check_defaults(self, cs):
         self.assertEqual(cs.forcePedalOverCC, False)


### PR DESCRIPTION
Make sure read_config_file can be called with a single argument as before.