### PR TITLE
Better caching of user info for tinklad user analytics

### DIFF
--- a/cereal/tinkla.capnp
+++ b/cereal/tinkla.capnp
@@ -7,7 +7,7 @@ $Java.outerClassname("Tinkla");
 
 @0xfc8dda643156b95d;
 
-const interfaceVersion :Float32 = 2.0;
+const interfaceVersion :Float32 = 2.1;
 
 struct Interface {
 
@@ -23,7 +23,7 @@ struct Interface {
         version @0 :Float32;
 
         openPilotId @1 :Text;
-        reserved @2 :Text;
+        timestamp @2 :Text;
 
         userHandle @3 :Text;
         gitRemote @4 :Text;

--- a/selfdrive/tinklad/airtable_publisher.py
+++ b/selfdrive/tinklad/airtable_publisher.py
@@ -32,7 +32,6 @@ class TinklaEventValueTypes():
 class Publisher():
     openPilotId = None
     latest_info_dict = None # current info published
-    pending_info_dict = None 
     userRecordId = None
 
     def send_info(self, info, isData= False):
@@ -50,8 +49,6 @@ class Publisher():
                 return
 
         print(LOG_PREFIX + "Sending info. data=%s" % (data_dict))
-        self.pending_info_dict = data_dict
-
         if self.userRecordId != None:
             self.__update_user(data_dict)
 
@@ -72,21 +69,11 @@ class Publisher():
             self.__update_user(data_dict)
         
         self.latest_info_dict = data_dict
-        self.pending_info_dict = None
         print(LOG_PREFIX + "*send_info competed*")
 
     def send_event(self, event):
-        if self.pending_info_dict != None and self.pending_info_dict != self.latest_info_dict:
-            self.send_info(self.pending_info_dict, isData= True)
-
-        if self.openPilotId is None:
-            if self.latest_info_dict != None:
-                self.openPilotId = self.latest_info_dict[self.userKeys.openPilotId]
-            elif self.pending_info_dict != None:
-                print(LOG_PREFIX + "pending_data=%s" % (self.pending_info_dict))
-                self.openPilotId = self.pending_info_dict[self.userKeys.openPilotId]
-            else:
-                self.openPilotId = None
+        if self.openPilotId is None and self.latest_info_dict != None:
+            self.openPilotId = self.latest_info_dict[self.userKeys.openPilotId]
 
         event_dict = self.__generate_airtable_user_event_dict(event)
         print(LOG_PREFIX + "Sending event. data=%s" % (event_dict))

--- a/selfdrive/tinklad/tinkla_interface.py
+++ b/selfdrive/tinklad/tinkla_interface.py
@@ -38,6 +38,7 @@ class TinklaClient():
         if self.sock is None:
             return
 
+        info.timestamp = now_iso8601()
         message = tinkla.Interface.new_message()
         message.version = tinkla.interfaceVersion
         message.message.userInfo = info

--- a/selfdrive/tinklad/tinklad.py
+++ b/selfdrive/tinklad/tinklad.py
@@ -6,6 +6,7 @@ from pqueue import Queue
 from airtable_publisher import Publisher
 import requests
 import time
+import os 
 
 LOG_PREFIX = "tinklad: "
 
@@ -27,6 +28,8 @@ class TinklaInterfaceActions():
     attemptToSendPendingMessages = 'attemptToSendPendingMessages'
 
 class Cache():
+    name = ""
+
     def push(self, event):
         self.task_queue._put(event)
 
@@ -46,12 +49,21 @@ class Cache():
         return self.task_queue._qsize()
 
     def __open(self):
-        try:
-            self.task_queue = Queue("/data/tinklad-cache", tempdir="/data/local/tmp")
-        except OSError:
-            self.task_queue = Queue("./tinklad-cache", tempdir="./")
+        cacheDirectoryName = "tinklad-cache" + "/" + self.name
+        cachePath = None
+        tempdir = None
+        if os.path.exists("/data"):
+            cachePath = "/data/" + cacheDirectoryName 
+            tempdir="/data/local/tmp"
+        else: # Development environment:
+            cachePath = "./" + cacheDirectoryName
+            tempdir="./"
+        if not os.path.exists(cachePath):
+            os.makedirs(cachePath)
+        self.task_queue = Queue(cachePath, tempdir=tempdir)
 
-    def __init__(self):
+    def __init__(self, name):
+        self.name = name
         self.__open()
 
 
@@ -66,14 +78,30 @@ class TinklaServer():
             return
         self.last_attempt_time = now
 
-        if self.cache.count() == 0 and self.publisher.pending_info_dict == None:
+        if self.eventCache.count() == 0 and self.userInfoCache.count() == 0:
             return
         if not self.isOnline():
             return
         print(LOG_PREFIX + "Attempting to send pending messages")
+        self.publish_pending_userinfo()
         self.publish_pending_events()
 
     def setUserInfo(self, info, **kwargs):
+        self.userInfoCache.push(info)
+        self.publish_pending_userinfo()
+
+    def publish_pending_userinfo(self):
+        if self.userInfoCache.count() == 0:
+            return
+
+        print(LOG_PREFIX + 'User Info Cache has %d elements, attempting to publish...' %(self.userInfoCache.count()))
+        newest_record = self.userInfoCache.pop()
+        while self.userInfoCache.count() > 0:
+            record = self.userInfoCache.pop()
+            if record.timestamp > newest_record.timestamp:
+                newest_record = record 
+
+        info = newest_record
         print(LOG_PREFIX + "Sending info to publisher: %s" % (info.to_dict()))
         self.info = info
         try:
@@ -82,28 +110,28 @@ class TinklaServer():
             print(LOG_PREFIX + "Error attempting to publish user info (%s)" % (error))
 
     def logUserEvent(self, event, **kwargs):
-        self.cache.push(event)
+        self.eventCache.push(event)
         self.publish_pending_events()
 
     def publish_pending_events(self):
-        if self.cache.count() > 0:
-            print(LOG_PREFIX + 'Cache has %d elements, attempting to publish...' %(self.cache.count()))
+        if self.eventCache.count() > 0:
+            print(LOG_PREFIX + 'Cache has %d elements, attempting to publish...' %(self.eventCache.count()))
 
-        while self.cache.count() > 0:
-            event = self.cache.pop()
+        while self.eventCache.count() > 0:
+            event = self.eventCache.pop()
             if event.version != cereal.tinkla.interfaceVersion:
                 print(LOG_PREFIX + "Unsupported event version: %0.2f (supported version: %0.2f)" % (event.version, cereal.tinkla.interfaceVersion))
                 return
             try:
                 print(LOG_PREFIX + "Sending event to publisher: %s" % (event.to_dict()))
                 self.publisher.send_event(event)
-                self.cache.task_done()
+                self.eventCache.task_done()
             except AssertionError as error:
-                self.cache.push(event)
+                self.eventCache.push(event)
                 print(LOG_PREFIX + "Error attempting to publish, will retry later (%s)" % (error))
                 return
             except Exception as error: # pylint: disable=broad-except 
-                self.cache.push(event)
+                self.eventCache.push(event)
                 print(LOG_PREFIX + "Error attempting to publish, will retry later (%s)" % (error))
                 return
 
@@ -120,7 +148,9 @@ class TinklaServer():
     def __init__(self):
         self.publisher = Publisher()
         # set persitent cache for bad network / offline
-        self.cache = Cache()
+        self.eventCache = Cache("events")
+        self.userInfoCache = Cache("user_info")
+        self.publish_pending_userinfo()
         self.publish_pending_events()
         messageKeys = TinklaInterfaceMessageKeys()
         actions = TinklaInterfaceActions()


### PR DESCRIPTION
I had been meaning on doing this since I first wrote tinklad. Basically queues up the latest user update in a similar way as events. This is for offline/online stuff.

- [X] Tested in car