### PR TITLE
Avoid divison by zero as found in this crash report

### DIFF
--- a/selfdrive/car/modules/ALCA_module.py
+++ b/selfdrive/car/modules/ALCA_module.py
@@ -299,7 +299,11 @@ class ALCAModelParser(object):
     self.ALCA_r_poly = np.array(r_poly)
 
     #where are we in alca as %
-    ALCA_perc_complete = float(self.ALCA_step) / float(self.ALCA_total_steps)
+    if self.ALCA_total_steps != 0:
+      ALCA_perc_complete = float(self.ALCA_step) / float(self.ALCA_total_steps)
+    else:
+      ALCA_perc_complete = 0.0
+      
     if self.ALCA_error and self.ALCA_cancelling:
       self.debug_alca(" Error and Cancelling -> resetting...")
       self.reset_alca()


### PR DESCRIPTION
User Handle: CX25 OpenPilotId: ac7ae23eff865a4d
Git Remote: http://github.com/BogGyver/openpilot/
Branch: tesla_devel
Commit: f28fc9698abc9953834a4f60feba9efefce38ce2
Traceback (most recent call last):
  File `./manager.py`, line 193, in launcher
    mod.main()
  File `/data/openpilot/selfdrive/controls/plannerd.py`, line 51, in main
    plannerd_thread()
  File `/data/openpilot/selfdrive/controls/plannerd.py`, line 45, in plannerd_thread
    PP.update(sm, CP, VM)
  File `/data/openpilot/selfdrive/controls/lib/pathplanner.py`, line 66, in update
    self.MP.update(v_ego, sm[`model`],sm[`carState`])
  File `/data/openpilot/selfdrive/controls/lib/model_parser.py`, line 62, in update
    r_poly,l_poly,r_prob,l_prob,self.lane_width = self.ALCAMP.update(v_ego, md, cs, np.array(r_poly), np.array(l_poly), r_prob, l_prob, self.lane_width)
  File `/data/openpilot/selfdrive/car/modules/ALCA_module.py`, line 302, in update
    ALCA_perc_complete = float(self.ALCA_step) / float(self.ALCA_total_steps)
ZeroDivisionError: float division by zero