### PR TITLE
ALCA and radar_interface work

### DIFF
--- a/cereal/tesla.capnp
+++ b/cereal/tesla.capnp
@@ -35,6 +35,7 @@ struct TeslaRadarPoint {
   movingState @3 :UInt8; # 0-indeterminate 1-moving 2-stopped 3-standing
   length @4 :Float32; # length in meters
   obstacleProb @5 :Float32; # probability to be an obstacle
+  timeStamp @6 :UInt64; #timestamp when the pair was received
 }
 
 struct ICCarsLR {

--- a/selfdrive/car/tesla/radar_interface.py
+++ b/selfdrive/car/tesla/radar_interface.py
@@ -15,6 +15,7 @@ RADAR_A_MSGS = list(range(0x310, 0x36F , 3))
 RADAR_B_MSGS = list(range(0x311, 0x36F, 3))
 OBJECT_MIN_PROBABILITY = 20.
 CLASS_MIN_PROBABILITY = 20.
+RADAR_MESSAGE_FREQUENCY = 0.050 * 1e9 #time in ns, radar sends data at 0.06 s
 
 
 # Tesla Bosch firmware has 32 objects in all objects or a selected set of the 5 we should look at
@@ -66,7 +67,8 @@ class RadarInterface(object):
       self.logcan = messaging.sub_sock(service_list['can'].port)
       self.radarOffset = CarSettings().get_value("radarOffset")
       self.trackId = 1
-      self.trigger_msg = RADAR_B_MSGS[-1]
+      self.trigger_start_msg = RADAR_A_MSGS[0]
+      self.trigger_end_msg = RADAR_B_MSGS[-1]
 
 
 
@@ -77,14 +79,18 @@ class RadarInterface(object):
       time.sleep(0.05)
       return car.RadarData.new_message(),self.extPts.values()
 
+
     tm = int(sec_since_boot() * 1e9)
     if can_strings != None:
       vls = self.rcp.update_strings(tm, can_strings)
       self.updated_messages.update(vls)
 
-    #BB disable this to see if we really can prevent the Comm and CAN errors
-    #if self.trigger_msg not in self.updated_messages:
-    #  return None,None
+
+    if self.trigger_start_msg not in self.updated_messages:
+      return None,None
+
+    if self.trigger_end_msg not in self.updated_messages:
+      return None,None
 
     rr,rrext = self._update(self.updated_messages)
     self.updated_messages.clear()
@@ -101,61 +107,66 @@ class RadarInterface(object):
           del self.extPts[message]
         continue
       cpt = self.rcp.vl[message]
-      if (cpt['LongDist'] >= BOSCH_MAX_DIST) or (cpt['LongDist']==0) or (not cpt['Tracked']):
-        self.valid_cnt[message] = 0    # reset counter
-        if message in self.pts:
-          del self.pts[message]
-          del self.extPts[message]
-      elif cpt['Valid'] and (cpt['LongDist'] < BOSCH_MAX_DIST) and (cpt['LongDist'] > 0) and (cpt['ProbExist'] >= OBJECT_MIN_PROBABILITY):
-        self.valid_cnt[message] += 1
-      else:
-        self.valid_cnt[message] = max(self.valid_cnt[message] -1, 0)
-        if (self.valid_cnt[message]==0) and (message in self.pts):
-          del self.pts[message]
-          del self.extPts[message]
+      cpt2 = self.rcp.vl[message+1]
+      # ensure the two messages are from the same frame reading
+      #if self.rcp.ts[message+1] == self.rcp.ts[message]:
+      if abs(self.rcp.ts[message+1]['Index2']-self.rcp.ts[message]['Index']) < RADAR_MESSAGE_FREQUENCY:
+        if (cpt['LongDist'] >= BOSCH_MAX_DIST) or (cpt['LongDist']==0) or (not cpt['Tracked']):
+          self.valid_cnt[message] = 0    # reset counter
+          if message in self.pts:
+            del self.pts[message]
+            del self.extPts[message]
+        elif cpt['Valid'] and (cpt['LongDist'] < BOSCH_MAX_DIST) and (cpt['LongDist'] > 0) and (cpt['ProbExist'] >= OBJECT_MIN_PROBABILITY):
+          self.valid_cnt[message] += 1
+        else:
+          self.valid_cnt[message] = max(self.valid_cnt[message] -1, 0)
+          if (self.valid_cnt[message]==0) and (message in self.pts):
+            del self.pts[message]
+            del self.extPts[message]
 
-      #score = self.rcp.vl[ii+16]['SCORE']
-      #print ii, self.valid_cnt[ii], cpt['Valid'], cpt['LongDist'], cpt['LatDist']
+        #score = self.rcp.vl[ii+16]['SCORE']
+        #print ii, self.valid_cnt[ii], cpt['Valid'], cpt['LongDist'], cpt['LatDist']
 
-      # radar point only valid if it's a valid measurement and score is above 50
-      # bosch radar data needs to match Index and Index2 for validity
-      # also for now ignore construction elements
-      if (cpt['Valid'] or cpt['Tracked'])and (cpt['LongDist']>0) and (cpt['LongDist'] < BOSCH_MAX_DIST) and \
-          (cpt['Index'] == self.rcp.vl[message+1]['Index2']) and (self.valid_cnt[message] > 5) and \
-          (cpt['ProbExist'] >= OBJECT_MIN_PROBABILITY): # and (self.rcp.vl[ii+1]['Class'] < 4): # and ((self.rcp.vl[ii+1]['MovingState']<3) or (self.rcp.vl[ii+1]['Class'] > 0)):
-        if message not in self.pts and ( cpt['Tracked']):
-          self.pts[message] = car.RadarData.RadarPoint.new_message()
-          self.pts[message].trackId = self.trackId 
-          self.extPts[message] = tesla.TeslaRadarPoint.new_message()
-          self.extPts[message].trackId = self.trackId 
-          self.trackId = (self.trackId + 1) & 0xFFFFFFFFFFFFFFFF
-          if self.trackId ==0:
-            self.trackId = 1
-        if message in self.pts:
-          self.pts[message].dRel = cpt['LongDist']  # from front of car
-          self.pts[message].yRel = cpt['LatDist']  - self.radarOffset # in car frame's y axis, left is positive
-          self.pts[message].vRel = cpt['LongSpeed']
-          self.pts[message].aRel = cpt['LongAccel']
-          self.pts[message].yvRel = self.rcp.vl[message+1]['LatSpeed']
-          self.pts[message].measured = bool(cpt['Meas'])
-          self.extPts[message].dz = self.rcp.vl[message+1]['dZ']
-          self.extPts[message].movingState = self.rcp.vl[message+1]['MovingState']
-          self.extPts[message].length = self.rcp.vl[message+1]['Length']
-          self.extPts[message].obstacleProb = cpt['ProbObstacle']
-          if self.rcp.vl[message+1]['Class'] >= CLASS_MIN_PROBABILITY:
-            self.extPts[message].objectClass = self.rcp.vl[message+1]['Class']
-            # for now we will use class 0- unknown stuff to show trucks
-            # we will base that on being a class 1 and length of 2 (hoping they meant width not length, but as germans could not decide)
-            # 0-unknown 1-four wheel vehicle 2-two wheel vehicle 3-pedestrian 4-construction element
-            # going to 0-unknown 1-truck 2-car 3/4-motorcycle/bicycle 5 pedestrian - we have two bits so
-            if self.extPts[message].objectClass == 0:
+        # radar point only valid if it's a valid measurement and score is above 50
+        # bosch radar data needs to match Index and Index2 for validity
+        # also for now ignore construction elements
+        if (cpt['Valid'] or cpt['Tracked'])and (cpt['LongDist']>0) and (cpt['LongDist'] < BOSCH_MAX_DIST) and \
+            (cpt['Index'] == cpt2['Index2']) and (self.valid_cnt[message] > 5) and \
+            (cpt['ProbExist'] >= OBJECT_MIN_PROBABILITY): 
+          if message not in self.pts and ( cpt['Tracked']):
+            self.pts[message] = car.RadarData.RadarPoint.new_message()
+            self.pts[message].trackId = self.trackId 
+            self.extPts[message] = tesla.TeslaRadarPoint.new_message()
+            self.extPts[message].trackId = self.trackId 
+            self.trackId = (self.trackId + 1) & 0xFFFFFFFFFFFFFFFF
+            if self.trackId ==0:
+              self.trackId = 1
+          if message in self.pts:
+            self.pts[message].dRel = cpt['LongDist']  # from front of car
+            self.pts[message].yRel = cpt['LatDist']  - self.radarOffset # in car frame's y axis, left is positive
+            self.pts[message].vRel = cpt['LongSpeed']
+            self.pts[message].aRel = cpt['LongAccel']
+            self.pts[message].yvRel = cpt2['LatSpeed']
+            self.pts[message].measured = bool(cpt['Meas'])
+            self.extPts[message].dz = cpt2['dZ']
+            self.extPts[message].movingState = cpt2['MovingState']
+            self.extPts[message].length = cpt2['Length']
+            self.extPts[message].obstacleProb = cpt['ProbObstacle']
+            self.extPts[message].timeStamp = int(self.rcp.ts[message+1]['Index2'])
+            if self.rcp.vl[message+1]['Class'] >= CLASS_MIN_PROBABILITY:
+              self.extPts[message].objectClass = cpt2['Class']
+              # for now we will use class 0- unknown stuff to show trucks
+              # we will base that on being a class 1 and length of 2 (hoping they meant width not length, but as germans could not decide)
+              # 0-unknown 1-four wheel vehicle 2-two wheel vehicle 3-pedestrian 4-construction element
+              # going to 0-unknown 1-truck 2-car 3/4-motorcycle/bicycle 5 pedestrian - we have two bits so
+              if self.extPts[message].objectClass == 0:
+                self.extPts[message].objectClass = 1
+              if (self.extPts[message].objectClass == 1) and ((self.extPts[message].length >= 1.8) or (1.6 < self.extPts[message].dz < 4.5)):
+                self.extPts[message].objectClass = 0
+              if self.extPts[message].objectClass == 4:
+                self.extPts[message].objectClass = 1
+            else:
               self.extPts[message].objectClass = 1
-            if (self.extPts[message].objectClass == 1) and ((self.extPts[message].length >= 1.8) or (1.6 < self.extPts[message].dz < 4.5)):
-              self.extPts[message].objectClass = 0
-            if self.extPts[message].objectClass == 4:
-              self.extPts[message].objectClass = 1
-          else:
-            self.extPts[message].objectClass = 1
 
     ret.points = self.pts.values()
     errors = []
@@ -169,6 +180,7 @@ class RadarInterface(object):
       ret.errors = errors
     else:
       ret.errors = []
+    print ret,self.extPts.values()
     return ret,self.extPts.values()
 
 # radar_interface standalone tester

--- a/selfdrive/car/tesla/radar_interface.py
+++ b/selfdrive/car/tesla/radar_interface.py
@@ -180,7 +180,7 @@ class RadarInterface(object):
       ret.errors = errors
     else:
       ret.errors = []
-    print ret,self.extPts.values()
+    #print ret,self.extPts.values()
     return ret,self.extPts.values()
 
 # radar_interface standalone tester

--- a/selfdrive/car/tesla/radar_interface.py
+++ b/selfdrive/car/tesla/radar_interface.py
@@ -17,7 +17,7 @@ RADAR_B_MSGS = list(range(0x311, 0x36F, 3))
 OBJECT_MIN_PROBABILITY = 20.
 CLASS_MIN_PROBABILITY = 20.
 RADAR_MESSAGE_FREQUENCY = 0.050 * 1e9 #time in ns, radar sends data at 0.06 s
-VALID_THRESHOLD = 10
+VALID_MESSAGE_COUNT_THRESHOLD = 10
 
 
 # Tesla Bosch firmware has 32 objects in all objects or a selected set of the 5 we should look at
@@ -132,7 +132,7 @@ class RadarInterface(object):
       # bosch radar data needs to match Index and Index2 for validity
       # also for now ignore construction elements
       if (cpt['Valid'] or cpt['Tracked'])and (cpt['LongDist']>0) and (cpt['LongDist'] < BOSCH_MAX_DIST) and \
-          (self.valid_cnt[message] > VALID_THRESHOLD) and (cpt['ProbExist'] >= OBJECT_MIN_PROBABILITY): 
+          (self.valid_cnt[message] > VALID_MESSAGE_COUNT_THRESHOLD) and (cpt['ProbExist'] >= OBJECT_MIN_PROBABILITY): 
         if message not in self.pts and ( cpt['Tracked']):
           self.pts[message] = car.RadarData.RadarPoint.new_message()
           self.pts[message].trackId = self.trackId 

--- a/selfdrive/car/tesla/radar_interface.py
+++ b/selfdrive/car/tesla/radar_interface.py
@@ -7,6 +7,7 @@ from common.realtime import sec_since_boot
 from selfdrive.services import service_list
 import selfdrive.messaging as messaging
 from selfdrive.car.tesla.readconfig import CarSettings
+from selfdrive.tinklad.tinkla_interface import TinklaClient
 
 #RADAR_A_MSGS = list(range(0x371, 0x37F , 3))
 #RADAR_B_MSGS = list(range(0x372, 0x37F, 3))
@@ -49,6 +50,9 @@ def _create_radard_can_parser():
 
 
 class RadarInterface(object):
+
+  tinklaClient = TinklaClient()
+
   def __init__(self,CP):
     # radar
     self.pts = {}
@@ -168,6 +172,7 @@ class RadarInterface(object):
     errors = []
     if not self.rcp.can_valid:
       errors.append("canError")
+      self.tinklaClient.logCANErrorEvent(source="radar_interface", canMessage=0, additionalInformation="Invalid CAN Count")
       self.canErrorCounter += 1
     else:
       self.canErrorCounter = 0
@@ -176,7 +181,6 @@ class RadarInterface(object):
       ret.errors = errors
     else:
       ret.errors = []
-    #print ret,self.extPts.values()
     return ret,self.extPts.values()
 
 # radar_interface standalone tester

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -261,7 +261,7 @@ def state_control(frame, rcv_frame, plan, path_plan, live_params, CS, CP, state,
   actuators.gas, actuators.brake = LoC.update(active, CS.vEgo, CS.brakePressed, CS.standstill, CS.cruiseState.standstill,
                                               v_cruise_kph, v_acc_sol, plan.vTargetFuture, a_acc_sol, CP)
   # Steering PID loop and lateral MPC
-  actuators.steer, actuators.steerAngle, lac_log = LaC.update(active, CS.vEgo, CS.steeringAngle, CS.steeringRate, CS.steeringTorqueEps, CS.steeringPressed, CP, VM, path_plan)
+  actuators.steer, actuators.steerAngle, lac_log = LaC.update(active, CS.vEgo, CS.steeringAngle, CS.steeringRate, CS.steeringTorqueEps, CS.steeringPressed, CP, VM, path_plan, live_params)
 
   # Send a "steering required alert" if saturation count has reached the limit
   if LaC.sat_flag and CP.steerLimitAlert:

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -24,7 +24,7 @@ def calc_d_poly(l_poly, r_poly, p_poly, l_prob, r_prob, lane_width):
 
 
 class LanePlanner(object):
-  def __init__(self):
+  def __init__(self,withAlca):
     self.l_poly = [0., 0., 0., 0.]
     self.r_poly = [0., 0., 0., 0.]
     self.p_poly = [0., 0., 0., 0.]
@@ -40,7 +40,9 @@ class LanePlanner(object):
 
     self._path_pinv = compute_path_pinv()
     self.x_points = np.arange(50)
-    self.ALCAMP = ALCAModelParser()
+    self.withAlca = withAlca
+    if withAlca:
+      self.ALCAMP = ALCAModelParser()
 
   def parse_model(self, md):
     if len(md.leftLane.poly):
@@ -70,8 +72,8 @@ class LanePlanner(object):
                       (1 - self.lane_width_certainty) * speed_lane_width
 
     # ALCA integration
-    if alca:
-      self.r_poly,self.l_poly,self.r_prob,self.l_prob,self.lane_width = self.ALCAMP.update(v_ego, md, np.array(self.r_poly), np.array(self.l_poly), self.r_prob, self.l_prob, self.lane_width)
+    if self.withAlca and alca:
+      self.r_poly,self.l_poly,self.r_prob,self.l_prob,self.lane_width, self.p_poly = self.ALCAMP.update(v_ego, md, np.array(self.r_poly), np.array(self.l_poly), self.r_prob, self.l_prob, self.lane_width, self.p_poly)
 
     self.d_poly = calc_d_poly(self.l_poly, self.r_poly, self.p_poly, self.l_prob, self.r_prob, self.lane_width)
 

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -24,7 +24,7 @@ def calc_d_poly(l_poly, r_poly, p_poly, l_prob, r_prob, lane_width):
 
 
 class LanePlanner(object):
-  def __init__(self,withAlca):
+  def __init__(self,shouldUseAlca):
     self.l_poly = [0., 0., 0., 0.]
     self.r_poly = [0., 0., 0., 0.]
     self.p_poly = [0., 0., 0., 0.]
@@ -40,8 +40,8 @@ class LanePlanner(object):
 
     self._path_pinv = compute_path_pinv()
     self.x_points = np.arange(50)
-    self.withAlca = withAlca
-    if withAlca:
+    self.shouldUseAlca = shouldUseAlca
+    if shouldUseAlca:
       self.ALCAMP = ALCAModelParser()
 
   def parse_model(self, md):
@@ -72,7 +72,7 @@ class LanePlanner(object):
                       (1 - self.lane_width_certainty) * speed_lane_width
 
     # ALCA integration
-    if self.withAlca and alca:
+    if self.shouldUseAlca and alca:
       self.r_poly,self.l_poly,self.r_prob,self.l_prob,self.lane_width, self.p_poly = self.ALCAMP.update(v_ego, md, np.array(self.r_poly), np.array(self.l_poly), self.r_prob, self.l_prob, self.lane_width, self.p_poly)
 
     self.d_poly = calc_d_poly(self.l_poly, self.r_poly, self.p_poly, self.l_prob, self.r_prob, self.lane_width)

--- a/selfdrive/controls/lib/latcontrol_pid.py
+++ b/selfdrive/controls/lib/latcontrol_pid.py
@@ -14,7 +14,7 @@ class LatControlPID(object):
   def reset(self):
     self.pid.reset()
 
-  def update(self, active, v_ego, angle_steers, angle_steers_rate, eps_torque, steer_override, CP, VM, path_plan):
+  def update(self, active, v_ego, angle_steers, angle_steers_rate, eps_torque, steer_override, CP, VM, path_plan, live_params):
     pid_log = log.ControlsState.LateralPIDState.new_message()
     pid_log.steerAngle = float(angle_steers)
     pid_log.steerRate = float(angle_steers_rate)
@@ -24,7 +24,8 @@ class LatControlPID(object):
       pid_log.active = False
       self.pid.reset()
     else:
-      self.angle_steers_des = path_plan.angleSteers # get from MPC/PathPlanner
+      angle_bias = live_params.angleOffset - live_params.angleOffsetAverage
+      self.angle_steers_des = path_plan.angleSteers + angle_bias  # get from MPC/PathPlanner
 
       steers_max = get_steer_max(CP, v_ego)
       self.pid.pos_limit = steers_max

--- a/selfdrive/controls/lib/latcontrol_pid.py
+++ b/selfdrive/controls/lib/latcontrol_pid.py
@@ -25,7 +25,7 @@ class LatControlPID(object):
       self.pid.reset()
     else:
       angle_bias = live_params.angleOffset - live_params.angleOffsetAverage
-      self.angle_steers_des = path_plan.angleSteers + angle_bias  # get from MPC/PathPlanner
+      self.angle_steers_des = path_plan.angleSteers #+ angle_bias  # get from MPC/PathPlanner
 
       steers_max = get_steer_max(CP, v_ego)
       self.pid.pos_limit = steers_max

--- a/selfdrive/controls/lib/pathplanner.py
+++ b/selfdrive/controls/lib/pathplanner.py
@@ -11,7 +11,6 @@ from selfdrive.controls.lib.drive_helpers import MPC_COST_LAT
 from selfdrive.controls.lib.lane_planner import LanePlanner
 import selfdrive.messaging as messaging
 from selfdrive.car.tesla.readconfig import CarSettings
-from cereal import tesla
 
 LOG_MPC = os.environ.get('LOG_MPC', False)
 
@@ -24,13 +23,12 @@ def calc_states_after_delay(states, v_ego, steer_angle, curvature_factor, steer_
 
 class PathPlanner(object):
   def __init__(self, CP):
-    self.LP = LanePlanner()
+    self.LP = LanePlanner(True)
 
     self.last_cloudlog_t = 0
 
     self.plan = messaging.pub_sock(service_list['pathPlan'].port)
     self.livempc = messaging.pub_sock(service_list['liveMpc'].port)
-    self.alca = messaging.pub_sock(service_list['alcaState'].port)
 
     self.setup_mpc(CP.steerRateCost)
     self.solution_invalid_cnt = 0
@@ -134,18 +132,6 @@ class PathPlanner(object):
     plan_send.pathPlan.posenetValid = bool(sm['liveParameters'].posenetValid)
 
     self.plan.send(plan_send.to_bytes())
-
-    alca_state = tesla.ALCAState.new_message()
-    #ALCA params
-    alca_state.alcaDirection = int(self.LP.ALCAMP.ALCA_direction)
-    alca_state.alcaError = bool(self.LP.ALCAMP.ALCA_error)
-    alca_state.alcaCancelling = bool(self.LP.ALCAMP.ALCA_cancelling)
-    alca_state.alcaEnabled = bool(self.LP.ALCAMP.ALCA_enabled)
-    alca_state.alcaLaneWidth = float(self.LP.ALCAMP.ALCA_lane_width)
-    alca_state.alcaStep = int(self.LP.ALCAMP.ALCA_step)
-    alca_state.alcaTotalSteps = int(self.LP.ALCAMP.ALCA_total_steps)
-
-    self.alca.send(alca_state.to_bytes())
 
     if LOG_MPC:
       dat = messaging.new_message()

--- a/selfdrive/controls/lib/pathplanner.py
+++ b/selfdrive/controls/lib/pathplanner.py
@@ -23,7 +23,7 @@ def calc_states_after_delay(states, v_ego, steer_angle, curvature_factor, steer_
 
 class PathPlanner(object):
   def __init__(self, CP):
-    self.LP = LanePlanner(True)
+    self.LP = LanePlanner(shouldUseAlca=True)
 
     self.last_cloudlog_t = 0
 

--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -379,7 +379,7 @@ def radard_thread(gctx=None):
 
   rk = Ratekeeper(rate, print_delay_threshold=None)
   RD = RadarD(mocked, RI)
-  MP = LanePlanner(False)
+  MP = LanePlanner(shouldUseAlca=False)
 
   has_radar = not CP.radarOffCan or mocked
   last_md_ts = 0.

--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -349,12 +349,6 @@ class RadarD(object):
     datext.lead2trackId = l2x['trackId']
     datext.lead2oClass = l2x['oClass']
     datext.lead2length = l2x['length']
-    #datext.lead1trackId = l1x.trackId
-    #datext.lead1oClass = l1x.oClass
-    #datext.lead1length = l1x.length
-    #datext.lead2trackId = l2x.trackId
-    #datext.lead2oClass = l2x.oClass
-    #datext.lead2length = l2x.length
     return dat, datext
 
 
@@ -385,7 +379,7 @@ def radard_thread(gctx=None):
 
   rk = Ratekeeper(rate, print_delay_threshold=None)
   RD = RadarD(mocked, RI)
-  MP = LanePlanner()
+  MP = LanePlanner(False)
 
   has_radar = not CP.radarOffCan or mocked
   last_md_ts = 0.


### PR DESCRIPTION
- Improve ALCA integration by moving all signal publishers and changes into the ALCA_module
- increase # of errors before generating CAN error from radar to 3
- improve logic for parsing a full block of values by checking for start and end message presence
- re-add logic for angle_bias (but keep disabled)
- check at top if Index and Index2 from the 2 messages for each object match