### PR TITLE
ACC - Fix Auto Resume Braking and Speed-Up

### DIFF
--- a/selfdrive/car/tesla/HSO_module.py
+++ b/selfdrive/car/tesla/HSO_module.py
@@ -10,6 +10,7 @@ def _current_time_millis():
 class HSOController():
     def __init__(self,carcontroller):
         self.CC = carcontroller
+        self.human_control = False
         self.frame_humanSteered = 0
         self.turn_signal_needed = 0 # send 1 for left, 2 for right 0 for not needed
         self.last_blinker_on = 0
@@ -77,4 +78,5 @@ class HSOController():
           self.turn_signal_needed = 0
           self.blinker_on = 0
           self.last_blinker_on = 0
+        self.human_control = human_control
         return human_control and enabled, self.turn_signal_needed


### PR DESCRIPTION
This prevents auto resume from taking over shortly after braking by verifying you have not pressed the brake within 1 second. The speed-up fix prevents auto resume from instantly re-engaging after you have braked and are manual steering.

Edit: Cleaned up fix based on Bog's advice and opened new PR to not spam with commit messages. 