### PR TITLE
Disable HSO for 3 seconds after blinker has been active

### DIFF
--- a/selfdrive/car/tesla/HSO_module.py
+++ b/selfdrive/car/tesla/HSO_module.py
@@ -18,6 +18,7 @@ class HSOController():
         self.frame_blinker_on = 0
         self.last_human_blinker_on = 0
         self.frame_human_blinker_on = 0
+        self.HSO_numb_period = 150
     
 
     def update_stat(self,CC,CS,enabled,actuators,frame):
@@ -54,7 +55,7 @@ class HSOController():
               steer_current=(CS.angle_steers)  # Formula to convert current steering angle to match apply_steer calculated number
               apply_steer = int(-actuators.steerAngle)
               angle = abs(apply_steer-steer_current)
-              if angle > 15.:
+              if frame < (self.frame_blinker_on + self.HSO_numb_period) or angle > 15.:
                 self.frame_humanSteered = frame
         if enabled:
             if CS.enableHSO:


### PR DESCRIPTION
Avoid HSO will deactivate and try to take the car back into the lane during a manual lane change with blinker tapped (3 blinks mode)