### PR TITLE
Fix TeslaModel param file wasn't read correctly

### DIFF
--- a/selfdrive/car/tesla/carstate.py
+++ b/selfdrive/car/tesla/carstate.py
@@ -250,6 +250,8 @@ class CarState():
     # Tesla Model
     self.teslaModelDetected = 1
     self.teslaModel = read_db('/data/params','TeslaModel')
+    if self.teslaModel is not None:
+      self.teslaModel = self.teslaModel.decode()
     if self.teslaModel is None:
       self.teslaModel = "S"
       self.teslaModelDetected = 0

--- a/selfdrive/car/tesla/interface.py
+++ b/selfdrive/car/tesla/interface.py
@@ -103,6 +103,8 @@ class CarInterface():
     ret.isPandaBlack = is_panda_black
 
     teslaModel = read_db('/data/params','TeslaModel')
+    if teslaModel is not None:
+      teslaModel = teslaModel.decode()
     if teslaModel is None:
       teslaModel = "S"
 


### PR DESCRIPTION
This PR fixes why P cars used the same PID values as non performance. Python 3 file.read now returns a byte array which must be decoded first to get the string value.