### PR TITLE
Skip Date Check

### DIFF
--- a/selfdrive/car/tesla/PCC_module.py
+++ b/selfdrive/car/tesla/PCC_module.py
@@ -318,7 +318,7 @@ class PCCController:
         PEDAL_MAX_DOWN = MAX_PEDAL_VALUE * _DT / 0.4
         PEDAL_MAX_UP = (MAX_PEDAL_VALUE - self.prev_tesla_pedal) * _DT
 
-        BRAKE_LOOKUP_BP = [-3.5, 0.]
+        BRAKE_LOOKUP_BP = [-4.5, 0.]
         BRAKE_LOOKUP_V  = [ 1.0, 0.]
 
         enable_pedal = 1.0 if self.enable_pedal_cruise else 0.0

--- a/selfdrive/car/tesla/pedal_calibrator/calibratePedal.py
+++ b/selfdrive/car/tesla/pedal_calibrator/calibratePedal.py
@@ -296,6 +296,9 @@ class PedalCalibrator:
       #self.brakePressed = bool(self.cp.vl["BrakeMessage"]["driverBrakeStatus"] != 1)
       if not self.brakePressed:
         self.show_error(4)
+        if self.pedal_enabled == 1:
+          self.create_pedal_command_msg(0, 0, self.pedal_can)
+          self.pedal_enabled = 0
         continue
 
       #Gear
@@ -303,12 +306,18 @@ class PedalCalibrator:
       #self.gear_neutral = self.gearShifter == car.CarState.GearShifter.neutral
       if not self.gear_neutral:
         self.show_error(2)
+        if self.pedal_enabled == 1:
+          self.create_pedal_command_msg(0, 0, self.pedal_can)
+          self.pedal_enabled = 0
         continue
 
       #DI Pedal Level
       #self.di_gas = self.cp.vl["DI_torque1"]["DI_pedalPos"]
       if self.di_gas > 0 and self.status < 3:
         self.show_error(3)
+        if self.pedal_enabled == 1:
+          self.create_pedal_command_msg(0, 0, self.pedal_can)
+          self.pedal_enabled = 0
         continue
 
       #Pedal Msg

--- a/selfdrive/car/tesla/tunes.py
+++ b/selfdrive/car/tesla/tunes.py
@@ -41,8 +41,8 @@ PEDAL_V = [ [99., 99., 99., 99., 99., 99.], #1-S60
 ]
 #MPH                    0    3    16    33    55    90
 ACCEL_LOOKUP_BP =     [ 0.0, 1.3, 7.5, 15.0, 25.0, 40.0]
-ACCEL_MAX_LOOKUP_V  = [[0.3, 0.5, 0.9,  0.7,  0.6,  0.5], #1-Chill
-                       [0.3, 0.6, 1.2,  1.0,  0.8,  0.6], #2-Standard
+ACCEL_MAX_LOOKUP_V  = [[0.3, 0.7, 0.9,  0.7,  0.6,  0.5], #1-Chill
+                       [0.3, 0.9, 1.2,  1.0,  0.8,  0.6], #2-Standard
                        [0.3, 1.6, 1.9,  1.5,  1.2,  1.0], #3-MadMax
 ]
 ACCEL_MIN_LOOKUP_V =  [TESLA_MIN_ACCEL, TESLA_MIN_ACCEL, TESLA_MIN_ACCEL, TESLA_MIN_ACCEL, TESLA_MIN_ACCEL, TESLA_MIN_ACCEL]
@@ -56,13 +56,13 @@ def set_long_tune(tune, name):
     tune.kpBP = [0.0, 5.0, 22.0, 35.0]
     tune.kiBP = [0.0, 5.0, 22.0, 35.0]
     tune.kpV = [0.75, 0.75, 0.75, 0.75]
-    tune.kiV = [0.07, 0.05, 0.03, 0.01]
+    tune.kiV = [0.07, 0.07, 0.07, 0.07]
   # Default longitudinal tune
   elif name == LongTunes.IBST:
     tune.kpBP = [0.0, 5.0, 22.0, 35.0]
     tune.kiBP = [0.0, 5.0, 22.0, 35.0]
     tune.kpV = [0.50, 0.50, 0.45, 0.40]
-    tune.kiV = [0.05, 0.04, 0.03, 0.01]
+    tune.kiV = [0.05, 0.05, 0.05, 0.05]
   elif name == LongTunes.ACC:
     tune.kpBP = [0]
     tune.kiBP = [0]

--- a/selfdrive/car/tesla/tunes.py
+++ b/selfdrive/car/tesla/tunes.py
@@ -56,13 +56,13 @@ def set_long_tune(tune, name):
     tune.kpBP = [0.0, 5.0, 22.0, 35.0]
     tune.kiBP = [0.0, 5.0, 22.0, 35.0]
     tune.kpV = [0.75, 0.75, 0.75, 0.75]
-    tune.kiV = [0.07, 0.07, 0.07, 0.07]
+    tune.kiV = [0.07, 0.05, 0.03, 0.01]
   # Default longitudinal tune
   elif name == LongTunes.IBST:
     tune.kpBP = [0.0, 5.0, 22.0, 35.0]
     tune.kiBP = [0.0, 5.0, 22.0, 35.0]
-    tune.kpV = [0.60, 0.60, 0.60, 0.60]
-    tune.kiV = [0.07, 0.07, 0.07, 0.07]
+    tune.kpV = [0.50, 0.50, 0.45, 0.40]
+    tune.kiV = [0.05, 0.04, 0.03, 0.01]
   elif name == LongTunes.ACC:
     tune.kpBP = [0]
     tune.kiBP = [0]

--- a/selfdrive/thermald/thermald.py
+++ b/selfdrive/thermald/thermald.py
@@ -331,7 +331,7 @@ def thermald_thread(end_event, hw_queue):
 
     # Ensure date/time are valid
     now = datetime.datetime.utcnow()
-    startup_conditions["time_valid"] = (now.year > 2020) or (now.year == 2020 and now.month >= 10)
+    startup_conditions["time_valid"] = (now.year > 1020) or (now.year == 1020 and now.month >= 10)
     set_offroad_alert_if_changed("Offroad_InvalidTime", (not startup_conditions["time_valid"]))
 
     startup_conditions["up_to_date"] = params.get("Offroad_ConnectivityNeeded") is None or params.get_bool("DisableUpdates") or params.get_bool("SnoozeUpdate")


### PR DESCRIPTION
Allows a rebooted EON to run even if the date is incorrect. Prevents need to connect to network upon restarting.

Better to put it on a menu toggle.

selfdrive\thermald\thermald.py
line 335:
# Ensure date/time are valid
    now = datetime.datetime.utcnow()
    startup_conditions["time_valid"] = (now.year > 2020) or (now.year == 2020 and now.month >= 10)

Change prev. line to:
    startup_conditions["time_valid"] = (now.year > 1020) or (now.year == 1020 and now.month >= 10)